### PR TITLE
Fix [Issue-89] combination of 'add' and 'subtract' months produce wrong 'date'

### DIFF
--- a/src/methods/since.js
+++ b/src/methods/since.js
@@ -31,7 +31,7 @@ function getDiff(a, b) {
   const isBefore = a.isBefore(b);
   const later = isBefore ? b : a;
   let earlier = isBefore ? a : b;
-  earlier = earlier.clone();
+  earlier = earlier.clone()
   const diff = {
     years: 0,
 
@@ -41,9 +41,9 @@ function getDiff(a, b) {
     minutes: 0,
     seconds: 0,
   };
-  Object.keys(diff).forEach(unit => {
+  Object.keys(diff).forEach((unit) => {
     if (earlier.isSame(later, unit)) {
-      return;
+      return
     }
     let max = earlier.diff(later, unit);
     
@@ -63,13 +63,13 @@ function getDiff(a, b) {
     if (max !== 0) {
       earlier = earlier.add(max, unit);
     }
-    diff[unit] = max;
-  });
+    diff[unit] = max
+  })
   //reverse it
   if (isBefore) {
     Object.keys(diff).forEach(u => {
       if (diff[u] !== 0) {
-        diff[u] *= -1;
+        diff[u] *= -1
       }
     });
   }
@@ -86,7 +86,7 @@ function pluralize(value, unit) {
 
 //create the human-readable diff between the two dates
 const since = function(start, end) {
-  end = fns.beADate(end, start);
+  end = fns.beADate(end, start)
   const diff = getDiff(start, end);
   const isNow = Object.keys(diff).every(u => !diff[u]);
   if (isNow === true) {
@@ -143,6 +143,6 @@ const since = function(start, end) {
     qualified: qualified,
     precise: precise
   };
-};
+}
 
 module.exports = since;

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -6,164 +6,213 @@ test('since()', t => {
   const a = spacetime('November 11, 1999 11:11:11', 'Canada/Eastern');
   const b = spacetime('December 12, 2000 12:12:12', 'Canada/Eastern');
 
-  t.deepEqual(b.since(a), {
-    diff: {
-      years: 1,
-      months: 1,
-      days: 1,
-      hours: 1,
-      minutes: 1,
-      seconds: 1
+  t.deepEqual(
+    b.since(a),
+    {
+      diff: {
+        years: 1,
+        months: 1,
+        days: 1,
+        hours: 1,
+        minutes: 1,
+        seconds: 1
+      },
+      rounded: '1 year ago',
+      qualified: '1 year ago',
+      precise: '1 year, 1 month ago'
     },
-    rounded: '1 year ago',
-    qualified: '1 year ago',
-    precise: '1 year, 1 month ago'
-  }, 'simple-ago')
+    'simple-ago'
+  );
 
-  t.deepEqual(a.since(b), {
-    diff: {
-      years: -1,
-      months: -1,
-      days: -1,
-      hours: -1,
-      minutes: -1,
-      seconds: -1
+  t.deepEqual(
+    a.since(b),
+    {
+      diff: {
+        years: -1,
+        months: -1,
+        days: -1,
+        hours: -1,
+        minutes: -1,
+        seconds: -1
+      },
+      rounded: 'in 1 year',
+      qualified: 'in 1 year',
+      precise: 'in 1 year, 1 month'
     },
-    rounded: 'in 1 year',
-    qualified: 'in 1 year',
-    precise: 'in 1 year, 1 month'
-  }, 'simple-in')
+    'simple-in'
+  );
 
-  t.deepEqual(a.since(a), {
-    diff: {
-      years: 0,
-      months: 0,
-      days: 0,
-      hours: 0,
-      minutes: 0,
-      seconds: 0
+  t.deepEqual(
+    a.since(a),
+    {
+      diff: {
+        years: 0,
+        months: 0,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0
+      },
+      rounded: 'now',
+      qualified: 'now',
+      precise: 'now'
     },
-    rounded: 'now',
-    qualified: 'now',
-    precise: 'now'
-  }, 'same')
+    'same'
+  );
 
-  const almostTwoYears = a.clone().add(1, 'year').add(11, 'months')
-  const overTwoMonths = a.clone().add(2, 'months').add(11, 'days')
-  const yearAndASecond = a.clone().add(1, 'year').add(1, 'second')
-  const twoSeconds = a.clone().add(2, 'seconds')
+  const almostTwoYears = a
+    .clone()
+    .add(1, 'year')
+    .add(11, 'months');
+  const overTwoMonths = a
+    .clone()
+    .add(2, 'months')
+    .add(11, 'days');
+  const yearAndASecond = a
+    .clone()
+    .add(1, 'year')
+    .add(1, 'second');
+  const twoSeconds = a.clone().add(2, 'seconds');
 
-  t.deepEqual(a.since(almostTwoYears), {
-    diff: {
-      years: -1,
-      months: -11,
-      days: -0,
-      hours: -0,
-      minutes: -0,
-      seconds: -0
+  t.deepEqual(
+    a.since(almostTwoYears),
+    {
+      diff: {
+        years: -1,
+        months: -11,
+        days: -0,
+        hours: -0,
+        minutes: -0,
+        seconds: -0
+      },
+      rounded: 'in 2 years',
+      qualified: 'in almost 2 years',
+      precise: 'in 1 year, 11 months'
     },
-    rounded: 'in 2 years',
-    qualified: 'in almost 2 years',
-    precise: 'in 1 year, 11 months'
-  }, 'almost')
+    'almost'
+  );
 
-  t.deepEqual(a.since(overTwoMonths), {
-    diff: {
-      years: -0,
-      months: -2,
-      days: -11,
-      hours: -0,
-      minutes: -0,
-      seconds: -0
+  t.deepEqual(
+    a.since(overTwoMonths),
+    {
+      diff: {
+        years: -0,
+        months: -2,
+        days: -11,
+        hours: -0,
+        minutes: -0,
+        seconds: -0
+      },
+      rounded: 'in 2 months',
+      qualified: 'in over 2 months',
+      precise: 'in 2 months, 11 days'
     },
-    rounded: 'in 2 months',
-    qualified: 'in over 2 months',
-    precise: 'in 2 months, 11 days'
-  }, 'over')
+    'over'
+  );
 
-  t.deepEqual(a.since(yearAndASecond), {
-    diff: {
-      years: -1,
-      months: -0,
-      days: -0,
-      hours: -0,
-      minutes: -0,
-      seconds: -1
+  t.deepEqual(
+    a.since(yearAndASecond),
+    {
+      diff: {
+        years: -1,
+        months: -0,
+        days: -0,
+        hours: -0,
+        minutes: -0,
+        seconds: -1
+      },
+      rounded: 'in 1 year',
+      qualified: 'in 1 year',
+      precise: 'in 1 year, 1 second'
     },
-    rounded: 'in 1 year',
-    qualified: 'in 1 year',
-    precise: 'in 1 year, 1 second'
-  }, 'precise')
+    'precise'
+  );
 
-  t.deepEqual(a.since(twoSeconds), {
-    diff: {
-      years: -0,
-      months: -0,
-      days: -0,
-      hours: -0,
-      minutes: -0,
-      seconds: -2
+  t.deepEqual(
+    a.since(twoSeconds),
+    {
+      diff: {
+        years: -0,
+        months: -0,
+        days: -0,
+        hours: -0,
+        minutes: -0,
+        seconds: -2
+      },
+      rounded: 'in 2 seconds',
+      qualified: 'in 2 seconds',
+      precise: 'in 2 seconds'
     },
-    rounded: 'in 2 seconds',
-    qualified: 'in 2 seconds',
-    precise: 'in 2 seconds'
-  }, 'seconds')
+    'seconds'
+  );
 
+  t.end();
+});
+
+test('since calculation involves Feb', t => {
+  let prev = spacetime('2019-01-31T23:00:50.0Z');
+  let now = spacetime('2019-02-01T10:00:00.0Z');
+  t.deepEqual(now.since(prev), {
+    diff: { years: 0, months: 0, days: 0, hours: 10, minutes: 59, seconds: 10 },
+    rounded: '11 hours ago',
+    qualified: 'almost 11 hours ago',
+    precise: '10 hours, 59 minutes ago'
+  });
   t.end();
 });
 
 test('since now - default', t => {
-  const past = spacetime.now()
+  const past = spacetime
+    .now()
     .subtract(23, 'months')
-    .subtract(23, 'seconds')
-  const since = past.since()
-  t.equal(since.diff.years, -1, '1 year back')
-  t.equal(since.diff.months, -11, '11 months back')
-  t.equal(since.diff.seconds, -23, '23 seconds back')
-  t.equal(since.precise, 'in 1 year, 11 months', 'precise is good')
+    .subtract(23, 'seconds');
+  const since = past.since();
+  t.equal(since.diff.years, -1, '1 year back');
+  t.equal(since.diff.months, -11, '11 months back');
+  t.equal(since.diff.seconds, -23, '23 seconds back');
+  t.equal(since.precise, 'in 1 year, 11 months', 'precise is good');
   t.end();
 });
 
 test('supports soft inputs', t => {
-  let now = spacetime([2019, 3, 12])
-  let c = spacetime('dec 25 2018')
-  c.year(now.year() - 1)
-  let obj = now.since(c).diff
-  t.equal(obj.months, 3, 'christmas was 3 months ago')
+  let now = spacetime([2019, 3, 12]);
+  let c = spacetime('dec 25 2018');
+  c.year(now.year() - 1);
+  let obj = now.since(c).diff;
+  t.equal(obj.months, 3, 'christmas was 3 months ago');
 
-  obj = spacetime('christmas').diff('new years')
-  t.equal(obj.days, 6, '6 days between christmas and new years')
+  obj = spacetime('christmas').diff('new years');
+  t.equal(obj.days, 6, '6 days between christmas and new years');
 
-  obj = spacetime('April 12th 2018').since('April 10th 2018')
-  t.equal(obj.rounded, '2 days ago', 'rounded')
-  t.equal(obj.qualified, '2 days ago', 'qualified')
-  t.equal(obj.precise, '2 days ago', 'precise')
-  let diff = obj.diff
-  t.equal(diff.years, 0, '0 years')
-  t.equal(diff.months, 0, '0 months')
-  t.equal(diff.days, 2, '2 days')
-  t.equal(diff.hours, 0, '0 hours')
-  t.equal(diff.seconds, 0, '0 seconds')
+  obj = spacetime('April 12th 2018').since('April 10th 2018');
+  t.equal(obj.rounded, '2 days ago', 'rounded');
+  t.equal(obj.qualified, '2 days ago', 'qualified');
+  t.equal(obj.precise, '2 days ago', 'precise');
+  let diff = obj.diff;
+  t.equal(diff.years, 0, '0 years');
+  t.equal(diff.months, 0, '0 months');
+  t.equal(diff.days, 2, '2 days');
+  t.equal(diff.hours, 0, '0 hours');
+  t.equal(diff.seconds, 0, '0 seconds');
 
   //opposite since logic
-  obj = spacetime('April 8th 2018').since('April 10th 2018')
-  t.equal(obj.rounded, 'in 2 days', 'rounded')
-  t.equal(obj.qualified, 'in 2 days', 'qualified')
-  t.equal(obj.precise, 'in 2 days', 'precise')
-  diff = obj.diff
-  t.equal(diff.years, 0, '0 years')
-  t.equal(diff.months, 0, '0 months')
-  t.equal(diff.days, -2, '2 days')
-  t.equal(diff.hours, 0, '0 hours')
-  t.equal(diff.seconds, 0, '0 seconds')
+  obj = spacetime('April 8th 2018').since('April 10th 2018');
+  t.equal(obj.rounded, 'in 2 days', 'rounded');
+  t.equal(obj.qualified, 'in 2 days', 'qualified');
+  t.equal(obj.precise, 'in 2 days', 'precise');
+  diff = obj.diff;
+  t.equal(diff.years, 0, '0 years');
+  t.equal(diff.months, 0, '0 months');
+  t.equal(diff.days, -2, '2 days');
+  t.equal(diff.hours, 0, '0 hours');
+  t.equal(diff.seconds, 0, '0 seconds');
 
   t.end();
 });
 
-
 test('from + fromNow aliases', t => {
-  let obj = spacetime('April 12th 2008', 'Canada/Eastern').from('March 12 2018')
-  t.equal(obj.qualified, 'almost 10 years ago', 'qualified')
-  t.equal(obj.precise, '9 years, 11 months ago', 'precise')
+  let obj = spacetime('April 12th 2008', 'Canada/Eastern').from('March 12 2018');
+  t.equal(obj.qualified, 'almost 10 years ago', 'qualified');
+  t.equal(obj.precise, '9 years, 11 months ago', 'precise');
   t.end();
 });

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -6,146 +6,165 @@ test('since()', t => {
   const a = spacetime('November 11, 1999 11:11:11', 'Canada/Eastern');
   const b = spacetime('December 12, 2000 12:12:12', 'Canada/Eastern');
 
-  t.deepEqual(
-    b.since(a),
-    {
-      diff: {
-        years: 1,
-        months: 1,
-        days: 1,
-        hours: 1,
-        minutes: 1,
-        seconds: 1
-      },
-      rounded: '1 year ago',
-      qualified: '1 year ago',
-      precise: '1 year, 1 month ago'
+  t.deepEqual(b.since(a), {
+    diff: {
+      years: 1,
+      months: 1,
+      days: 1,
+      hours: 1,
+      minutes: 1,
+      seconds: 1
     },
-    'simple-ago'
-  );
+    rounded: '1 year ago',
+    qualified: '1 year ago',
+    precise: '1 year, 1 month ago'
+  }, 'simple-ago')
 
-  t.deepEqual(
-    a.since(b),
-    {
-      diff: {
-        years: -1,
-        months: -1,
-        days: -1,
-        hours: -1,
-        minutes: -1,
-        seconds: -1
-      },
-      rounded: 'in 1 year',
-      qualified: 'in 1 year',
-      precise: 'in 1 year, 1 month'
+  t.deepEqual(a.since(b), {
+    diff: {
+      years: -1,
+      months: -1,
+      days: -1,
+      hours: -1,
+      minutes: -1,
+      seconds: -1
     },
-    'simple-in'
-  );
+    rounded: 'in 1 year',
+    qualified: 'in 1 year',
+    precise: 'in 1 year, 1 month'
+  }, 'simple-in')
 
-  t.deepEqual(
-    a.since(a),
-    {
-      diff: {
-        years: 0,
-        months: 0,
-        days: 0,
-        hours: 0,
-        minutes: 0,
-        seconds: 0
-      },
-      rounded: 'now',
-      qualified: 'now',
-      precise: 'now'
+  t.deepEqual(a.since(a), {
+    diff: {
+      years: 0,
+      months: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0
     },
-    'same'
-  );
+    rounded: 'now',
+    qualified: 'now',
+    precise: 'now'
+  }, 'same')
 
-  const almostTwoYears = a
-    .clone()
-    .add(1, 'year')
-    .add(11, 'months');
-  const overTwoMonths = a
-    .clone()
-    .add(2, 'months')
-    .add(11, 'days');
-  const yearAndASecond = a
-    .clone()
-    .add(1, 'year')
-    .add(1, 'second');
-  const twoSeconds = a.clone().add(2, 'seconds');
+  const almostTwoYears = a.clone().add(1, 'year').add(11, 'months')
+  const overTwoMonths = a.clone().add(2, 'months').add(11, 'days')
+  const yearAndASecond = a.clone().add(1, 'year').add(1, 'second')
+  const twoSeconds = a.clone().add(2, 'seconds')
 
-  t.deepEqual(
-    a.since(almostTwoYears),
-    {
-      diff: {
-        years: -1,
-        months: -11,
-        days: -0,
-        hours: -0,
-        minutes: -0,
-        seconds: -0
-      },
-      rounded: 'in 2 years',
-      qualified: 'in almost 2 years',
-      precise: 'in 1 year, 11 months'
+  t.deepEqual(a.since(almostTwoYears), {
+    diff: {
+      years: -1,
+      months: -11,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -0
     },
-    'almost'
-  );
+    rounded: 'in 2 years',
+    qualified: 'in almost 2 years',
+    precise: 'in 1 year, 11 months'
+  }, 'almost')
 
-  t.deepEqual(
-    a.since(overTwoMonths),
-    {
-      diff: {
-        years: -0,
-        months: -2,
-        days: -11,
-        hours: -0,
-        minutes: -0,
-        seconds: -0
-      },
-      rounded: 'in 2 months',
-      qualified: 'in over 2 months',
-      precise: 'in 2 months, 11 days'
+  t.deepEqual(a.since(overTwoMonths), {
+    diff: {
+      years: -0,
+      months: -2,
+      days: -11,
+      hours: -0,
+      minutes: -0,
+      seconds: -0
     },
-    'over'
-  );
+    rounded: 'in 2 months',
+    qualified: 'in over 2 months',
+    precise: 'in 2 months, 11 days'
+  }, 'over')
 
-  t.deepEqual(
-    a.since(yearAndASecond),
-    {
-      diff: {
-        years: -1,
-        months: -0,
-        days: -0,
-        hours: -0,
-        minutes: -0,
-        seconds: -1
-      },
-      rounded: 'in 1 year',
-      qualified: 'in 1 year',
-      precise: 'in 1 year, 1 second'
+  t.deepEqual(a.since(yearAndASecond), {
+    diff: {
+      years: -1,
+      months: -0,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -1
     },
-    'precise'
-  );
+    rounded: 'in 1 year',
+    qualified: 'in 1 year',
+    precise: 'in 1 year, 1 second'
+  }, 'precise')
 
-  t.deepEqual(
-    a.since(twoSeconds),
-    {
-      diff: {
-        years: -0,
-        months: -0,
-        days: -0,
-        hours: -0,
-        minutes: -0,
-        seconds: -2
-      },
-      rounded: 'in 2 seconds',
-      qualified: 'in 2 seconds',
-      precise: 'in 2 seconds'
+  t.deepEqual(a.since(twoSeconds), {
+    diff: {
+      years: -0,
+      months: -0,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -2
     },
-    'seconds'
-  );
+    rounded: 'in 2 seconds',
+    qualified: 'in 2 seconds',
+    precise: 'in 2 seconds'
+  }, 'seconds')
 
+  t.end();
+});
+
+test('since now - default', t => {
+  const past = spacetime.now()
+    .subtract(23, 'months')
+    .subtract(23, 'seconds')
+  const since = past.since()
+  t.equal(since.diff.years, -1, '1 year back')
+  t.equal(since.diff.months, -11, '11 months back')
+  t.equal(since.diff.seconds, -23, '23 seconds back')
+  t.equal(since.precise, 'in 1 year, 11 months', 'precise is good')
+  t.end();
+});
+
+test('supports soft inputs', t => {
+  let now = spacetime([2019, 3, 12])
+  let c = spacetime('dec 25 2018')
+  c.year(now.year() - 1)
+  let obj = now.since(c).diff
+  t.equal(obj.months, 3, 'christmas was 3 months ago')
+
+  obj = spacetime('christmas').diff('new years')
+  t.equal(obj.days, 6, '6 days between christmas and new years')
+
+  obj = spacetime('April 12th 2018').since('April 10th 2018')
+  t.equal(obj.rounded, '2 days ago', 'rounded')
+  t.equal(obj.qualified, '2 days ago', 'qualified')
+  t.equal(obj.precise, '2 days ago', 'precise')
+  let diff = obj.diff
+  t.equal(diff.years, 0, '0 years')
+  t.equal(diff.months, 0, '0 months')
+  t.equal(diff.days, 2, '2 days')
+  t.equal(diff.hours, 0, '0 hours')
+  t.equal(diff.seconds, 0, '0 seconds')
+
+  //opposite since logic
+  obj = spacetime('April 8th 2018').since('April 10th 2018')
+  t.equal(obj.rounded, 'in 2 days', 'rounded')
+  t.equal(obj.qualified, 'in 2 days', 'qualified')
+  t.equal(obj.precise, 'in 2 days', 'precise')
+  diff = obj.diff
+  t.equal(diff.years, 0, '0 years')
+  t.equal(diff.months, 0, '0 months')
+  t.equal(diff.days, -2, '2 days')
+  t.equal(diff.hours, 0, '0 hours')
+  t.equal(diff.seconds, 0, '0 seconds')
+
+  t.end();
+});
+
+
+test('from + fromNow aliases', t => {
+  let obj = spacetime('April 12th 2008', 'Canada/Eastern').from('March 12 2018')
+  t.equal(obj.qualified, 'almost 10 years ago', 'qualified')
+  t.equal(obj.precise, '9 years, 11 months ago', 'precise')
   t.end();
 });
 
@@ -169,61 +188,5 @@ test('since calculation involves month addition and subtraction', t => {
     precise: '23 hours ago'
   });
 
-  t.end();
-});
-
-test('since now - default', t => {
-  const past = spacetime
-    .now()
-    .subtract(23, 'months')
-    .subtract(23, 'seconds');
-  const since = past.since();
-  t.equal(since.diff.years, -1, '1 year back');
-  t.equal(since.diff.months, -11, '11 months back');
-  t.equal(since.diff.seconds, -23, '23 seconds back');
-  t.equal(since.precise, 'in 1 year, 11 months', 'precise is good');
-  t.end();
-});
-
-test('supports soft inputs', t => {
-  let now = spacetime([2019, 3, 12]);
-  let c = spacetime('dec 25 2018');
-  c.year(now.year() - 1);
-  let obj = now.since(c).diff;
-  t.equal(obj.months, 3, 'christmas was 3 months ago');
-
-  obj = spacetime('christmas').diff('new years');
-  t.equal(obj.days, 6, '6 days between christmas and new years');
-
-  obj = spacetime('April 12th 2018').since('April 10th 2018');
-  t.equal(obj.rounded, '2 days ago', 'rounded');
-  t.equal(obj.qualified, '2 days ago', 'qualified');
-  t.equal(obj.precise, '2 days ago', 'precise');
-  let diff = obj.diff;
-  t.equal(diff.years, 0, '0 years');
-  t.equal(diff.months, 0, '0 months');
-  t.equal(diff.days, 2, '2 days');
-  t.equal(diff.hours, 0, '0 hours');
-  t.equal(diff.seconds, 0, '0 seconds');
-
-  //opposite since logic
-  obj = spacetime('April 8th 2018').since('April 10th 2018');
-  t.equal(obj.rounded, 'in 2 days', 'rounded');
-  t.equal(obj.qualified, 'in 2 days', 'qualified');
-  t.equal(obj.precise, 'in 2 days', 'precise');
-  diff = obj.diff;
-  t.equal(diff.years, 0, '0 years');
-  t.equal(diff.months, 0, '0 months');
-  t.equal(diff.days, -2, '2 days');
-  t.equal(diff.hours, 0, '0 hours');
-  t.equal(diff.seconds, 0, '0 seconds');
-
-  t.end();
-});
-
-test('from + fromNow aliases', t => {
-  let obj = spacetime('April 12th 2008', 'Canada/Eastern').from('March 12 2018');
-  t.equal(obj.qualified, 'almost 10 years ago', 'qualified');
-  t.equal(obj.precise, '9 years, 11 months ago', 'precise');
   t.end();
 });

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -149,7 +149,7 @@ test('since()', t => {
   t.end();
 });
 
-test('since calculation involves Feb', t => {
+test('since calculation involves month addition and subtraction', t => {
   let prev = spacetime('2019-01-31T23:00:50.0Z');
   let now = spacetime('2019-02-01T10:00:00.0Z');
   t.deepEqual(now.since(prev), {
@@ -158,6 +158,17 @@ test('since calculation involves Feb', t => {
     qualified: 'almost 11 hours ago',
     precise: '10 hours, 59 minutes ago'
   });
+
+  prev = spacetime('2019-08-31T12:00:00.0Z');
+  now = spacetime('2019-09-01T11:00:00.0Z');
+
+  t.deepEqual(now.since(prev), {
+    diff: { years: 0, months: 0, days: 0, hours: 23, minutes: 0, seconds: 0 },
+    rounded: '23 hours ago',
+    qualified: '23 hours ago',
+    precise: '23 hours ago'
+  });
+
   t.end();
 });
 


### PR DESCRIPTION
## Cause
Month addition and subtraction have a desired 'date' adjusting that keeps 'date' legitimate for the resulting month, this can cause original 'date' been lost when performing 'add 1 month then subtract 1 month' as seen in **getDiff** function.

Eg:
_31 Jan 2019_ adds 1 month resulting _28 Feb 2019_ which when subtracts 1 month resulting _28 Jan 2019_ 

## Fix

The purpose of 'adding then subtracting' months is just to extract the actual month difference, therefor an **'earlier'** date object clone can be use to calculate the actual difference, then the difference can apply back to the **earlier** date object to keep the original 'date' and also adjusted for the destination month.

The added tests passed along with all other tests.