### PR TITLE
fix week calculate issue cause by cross dst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 viz/
 coverage/
 coverage.lcov
+.vscode
+.gitignore

--- a/scratch.js
+++ b/scratch.js
@@ -5,3 +5,8 @@ let a = spacetime(str)
 setTimeout(() => {
   console.log(a.isEqual(str))
 })
+
+a = spacetime('2018-03-29 00:00:0.0');
+b = a.clone().add(1, 'week')
+console.log(b.diff(a))
+console.log(b.since(a))

--- a/src/methods/add.js
+++ b/src/methods/add.js
@@ -18,7 +18,7 @@ let keep = {
   decade: order,
   century: order,
 };
-keep.week = keep.date;
+keep.week = keep.hour;
 keep.season = keep.date;
 keep.quarter = keep.date;
 


### PR DESCRIPTION
seems not to 'walk' on the hours for week addition is the easiest solution, at least keep all tests happy.

there is another bug in since.js cause it outputs something like '6 days 47 hours', which seems also caused by dst crossing, should be fixed in a separate PR