### PR TITLE
Fix error about timezone #99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spacetime",
-  "version": "5.2.0",
+  "version": "5.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2852,6 +2852,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3176,7 +3177,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3260,6 +3262,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3306,7 +3309,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3572,7 +3576,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/fns.js
+++ b/src/fns.js
@@ -87,3 +87,10 @@ exports.beADate = function(d, s) {
   }
   return d
 }
+
+exports.formatTimezone = function(offset, delimiter){
+  delimiter = delimiter || ''
+  const absOffset = Math.abs(offset)
+  const sign = offset > 0 ? '+' : '-'
+  return `${sign}${exports.zeroPad(absOffset)}${delimiter}00`
+}

--- a/src/methods/format/unixFmt.js
+++ b/src/methods/format/unixFmt.js
@@ -1,5 +1,6 @@
 'use strict'
 const pad = require('../../fns').zeroPad
+const formatTimezone = require('../../fns').formatTimezone
 //parse this insane unix-time-templating thing, from the 19th century
 //http://unicode.org/reports/tr35/tr35-25.html#Date_Format_Patterns
 
@@ -84,10 +85,10 @@ const mapping = {
   zz: (s) => s.timezone().name,
   zzz: (s) => s.timezone().name,
   zzzz: (s) => s.timezone().name,
-  Z: (s) => s.timezone().current.offset + '00',
-  ZZ: (s) => s.timezone().current.offset + '00',
-  ZZZ: (s) => s.timezone().current.offset + '00',
-  ZZZZ: (s) => s.timezone().current.offset + ':00',
+  Z: (s) => formatTimezone(s.timezone().current.offset),
+  ZZ: (s) => formatTimezone(s.timezone().current.offset),
+  ZZZ: (s) => formatTimezone(s.timezone().current.offset),
+  ZZZZ: (s) => formatTimezone(s.timezone().current.offset, ':'),
 
 }
 

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -39,6 +39,10 @@ test('unix-formatting', t => {
     [`EEE, MMM d, ''yy`, 'Thu, Nov 16, \'17'],
     [`hh 'o''clock' a`, '11 oclock AM'],
     ['yyyyy.MMMM.dd GGG hh:mm aaa', '02017.November.16 AD 11:34 AM'],
+    ['yyyy-MM-ddTHH:mm:ssZ', '2017-11-16T11:34:25-0500'],
+    ['yyyy-MM-ddTHH:mm:ssZZ', '2017-11-16T11:34:25-0500'],
+    ['yyyy-MM-ddTHH:mm:ssZZZ', '2017-11-16T11:34:25-0500'],
+    ['yyyy-MM-ddTHH:mm:ssZZZZ', '2017-11-16T11:34:25-05:00'],
   ]
   arr.forEach((a) => {
     t.equal(s.unixFmt(a[0]), a[1], a[0])


### PR DESCRIPTION
I think that solution is this method:

```
exports.formatTimezone = function(offset, delimiter){
  delimiter = delimiter || ''
  const absOffset = Math.abs(offset)
  const sign = offset > 0 ? '+' : '-'
  return `${sign}${exports.zeroPad(absOffset)}${delimiter}00`
}

```

Note: There are some legacy test failed

![screen shot 2019-02-20 at 4 01 30 pm](https://user-images.githubusercontent.com/7611944/53124387-3cb5f600-3529-11e9-993a-b0d2b68b3bbe.png)
