### PR TITLE
add function to determine timezone with date border

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -128,14 +128,12 @@ const methods = {
     let offset = this.timezone().current.offset + (24 - hour);
     
     if (offset === 0) { tz = `GMT+0`; }
-      else {
-        if (offset >= 24) { tz = `GMT${24 - offset}`;
-          } else if (offset <= 24) { tz = `GMT+${offset}`; }
-      }
+      else if (offset >= 24) { tz = `GMT${24 - offset}`;
+      } else if (offset <= 24) { tz = `GMT+${offset}`; }
 
     console.log(`date border time zone: 
-    ${this.goto(tz)}`);
-    return this.goto(tz);
+    ${this.goto(tz).timezone()}`);
+    return this.goto(tz).timezone();
   }
 }
 // aliases

--- a/src/methods.js
+++ b/src/methods.js
@@ -121,6 +121,21 @@ const methods = {
     date += '\n     - ' + this.format('time')
     console.log('\n\n', date + '\n     - ' + tz.name + ' (' + tz.current.offset + ')')
     return this
+  },
+  dateBorder: function() {
+    let hour = this.now().format('time'), tz;
+      if (this.format('time').indexOf('a'||'p') !== -1) { hour += 12; }
+    let offset = this.timezone().current.offset + (24 - hour);
+    
+    if (offset === 0) { tz = `GMT+0`; }
+      else {
+        if (offset >= 24) { tz = `GMT${24 - offset}`;
+          } else if (offset <= 24) { tz = `GMT+${offset}`; }
+      }
+
+    console.log(`date border time zone: 
+    ${this.goto(tz)}`);
+    return this.goto(tz);
   }
 }
 // aliases

--- a/src/methods.js
+++ b/src/methods.js
@@ -123,17 +123,17 @@ const methods = {
     return this
   },
   dateBorder: function() {
-    let hour = this.now().format('time'), tz;
-      if (this.format('time').indexOf('a'||'p') !== -1) { hour += 12; }
-    let offset = this.timezone().current.offset + (24 - hour);
-    
-    if (offset === 0) { tz = `GMT+0`; }
-      else if (offset >= 24) { tz = `GMT${24 - offset}`;
-      } else if (offset <= 24) { tz = `GMT+${offset}`; }
-
-    console.log(`date border time zone: 
-    ${this.goto(tz).timezone()}`);
-    return this.goto(tz).timezone();
+    let time = this.now().format('time'), tz;
+    let hour = this.now().hour();
+      if ((time.indexOf('p') !== -1) 
+        && hour !== 12) { hour += 12; }
+    const offset = (24 - hour);
+      if (offset === 0) { tz = `GMT+0`; }
+        else if (offset >= 24) { tz = `GMT${24 - offset}`;
+        } else if (offset <= 24) { tz = `GMT+${offset}`; }
+    console.log('date border time zone:\n',
+    this.now().goto(tz).timezone());
+    return this.now().goto(tz).timezone();
   }
 }
 // aliases


### PR DESCRIPTION
Added a method `dateBorder` to `src/methods.js`:
1. gets current time (if it's in 12-hour format adds 12 hours)
2. gets current timezone offset
3. counts number of hours to the end of the day
4. timezone with new date is: offset + number of hours to the end of the day
5. logs and returns timezone with date border