### PR TITLE
Add a type declaration for spacetime.since()

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -51,6 +51,9 @@ export interface SpacetimeMain {
 
   /** given a date, count how many of various units to make the dates equal */
   diff(value: Spacetime | ParsableDate): Diff
+
+  /** create the human-readable diff between the two dates */
+  since(startDate: Spacetime, endDate: Spacetime): Since
 }
 
 /** The return types are not actually both number and Spacetime, but this aids in casting to the proper type */
@@ -190,6 +193,13 @@ export interface Diff {
   seconds: number
   weeks: number
   years: number
+}
+
+export interface Since {
+  rounded: string;
+  qualified: string;
+  precise: string;
+  diff: Diff;
 }
 
 /** set where the key is tz database name in lowercase, eg, 'america/denver' */

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -53,7 +53,7 @@ export interface SpacetimeMain {
   diff(value: Spacetime | ParsableDate): Diff
 
   /** create the human-readable diff between the two dates */
-  since(startDate: Spacetime, endDate: Spacetime): Since
+  since(value: Spacetime | ParsableDate): Since
 }
 
 /** The return types are not actually both number and Spacetime, but this aids in casting to the proper type */


### PR DESCRIPTION
I've noticed there is no type declaration for the since() method, so added a quick on in types.d.ts

Let me know if I've got the signature wrong but think it's more or less correct :)

Thanks for the wonderful library, I use it all the time!

J