### PR TITLE
fix(*): fix month input type

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -113,7 +113,7 @@ export interface Spacetime {
   date: (value?: number) => number & Spacetime
 
   /** set or return the zero-based month-number (0-11). Also accepts 'June', or 'oct'. */
-  month: (value?: string) => number & Spacetime
+  month: (value?: number | string) => number & Spacetime
 
   /** set or return the 4-digit year as an integer */
   year: (value?: number) => number & Spacetime


### PR DESCRIPTION
Small typescript fix

The api reference here https://observablehq.com/@spencermountain/spacetime-api states that `.month` method can set month with string or number input, but input value in types.d.ts was only of string type