### PR TITLE
Added .every() to type declaration

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -56,6 +56,9 @@ export interface Spacetime {
   /** round to either current, or +1 of this unit */
   nearest: (unit: TimeUnit) => Spacetime
 
+  /** list all dates up to a certain time */
+  every: (unit: TimeUnit, other: Spacetime) => Spacetime[]
+
   /** go to the beginning of the previous unit */
   last: (unit: TimeUnit) => Spacetime
 


### PR DESCRIPTION
Hi Spencer, thanks for creating this library. I found .every() missing from the type declaration file, so here I added it.