### PR TITLE
Adding a generic ParsableDate constructor definition

### DIFF
--- a/test/types/constructor.test.ts
+++ b/test/types/constructor.test.ts
@@ -1,5 +1,6 @@
 import * as test from 'tape'
 import { spacetime } from './spacetime-static'
+import { ParsableDate } from '../../types/types'
 
 test('static api exists', (t: test.Test) => {
   t.equal(typeof spacetime, 'function', 'default is a function')
@@ -22,5 +23,6 @@ test('constructor args work', (t: test.Test) => {
     'accepts unit descriptor object'
   )
   t.equal(spacetime('2017-04-03').isValid(), true, 'accepts iso string')
+  t.equal(spacetime(<ParsableDate>'2017-04-03').isValid(), true, 'accepts datelike object')
   t.end()
 })

--- a/types/constructors.d.ts
+++ b/types/constructors.d.ts
@@ -1,4 +1,4 @@
-import { Spacetime } from './types'
+import { Spacetime, ParsableDate } from './types'
 
 export interface SpacetimeConstructorOptions {
   /** javascript dates use millisecond-epochs, instead of second-epochs, like some other languages. This is a common bug, and by default spacetime warns if you set an epoch within January 1970. to disable set to true */
@@ -52,6 +52,13 @@ export interface SpacetimeConstructor {
    * @param options Options for silencing warnings.
    */
   (iso: string, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
+
+  /**
+   * @param parsableDate a parsable date like object
+   * @param timezone Optional timezone. If omitted uses the browser timezone.
+   * @param options Options for silencing warnings.
+   */
+  (parsableDate: ParsableDate, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
 }
 
 export interface SpacetimeStatic extends SpacetimeConstructor {


### PR DESCRIPTION
Allows ParsableDate like objects to be used in the spacetime constructor