### PR TITLE
fixes non-standard iso-format overflow issue

### DIFF
--- a/src/input/parseTime.js
+++ b/src/input/parseTime.js
@@ -12,6 +12,9 @@ const parseTime = (s, str = '') => {
     if (arr[2].length < 2 || m < 0 || m > 59) {
       return s.startOf('day')
     }
+    if(arr[4] > 999) { // fix overflow issue with milliseconds, if input is longer than standard (e.g. 2017-08-06T09:00:00.123456Z)
+      arr[4] = parseInt(`${arr[4]}`.substring(0, 3), 10);
+    }
     s = s.hour(h)
     s = s.minute(m)
     s = s.seconds(arr[3] || 0)

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -131,7 +131,7 @@ test('inputs-in-comparisons', (t) => {
 })
 
 test('iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00:00Z')
+  let s = spacetime('2017-08-06T09:00.000Z')
   t.ok(s.isValid(), 'obj input is valid')
   t.equal(s.millisecond(), 0, 'iso-string-millisecond')
   t.equal(s.second(), 0, 'iso-string-second')
@@ -145,7 +145,7 @@ test('iso-string-input', (t) => {
 
 
 test('overlong-milliseconds-iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00:12345Z')
+  let s = spacetime('2017-08-06T09:00.12345Z')
   t.ok(s.isValid(), 'overlong obj input is valid')
   t.equal(s.millisecond(), 123, 'overlong-iso-string-millisecond')
   t.equal(s.second(), 0, 'overlong-iso-string-second')

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -131,7 +131,7 @@ test('inputs-in-comparisons', (t) => {
 })
 
 test('iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00.000Z')
+  let s = spacetime('2017-08-06T09:00:00.000Z')
   t.ok(s.isValid(), 'obj input is valid')
   t.equal(s.millisecond(), 0, 'iso-string-millisecond')
   t.equal(s.second(), 0, 'iso-string-second')
@@ -145,7 +145,7 @@ test('iso-string-input', (t) => {
 
 
 test('overlong-milliseconds-iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00.12345Z')
+  let s = spacetime('2017-08-06T09:00:00.12345Z')
   t.ok(s.isValid(), 'overlong obj input is valid')
   t.equal(s.millisecond(), 123, 'overlong-iso-string-millisecond')
   t.equal(s.second(), 0, 'overlong-iso-string-second')

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -143,6 +143,21 @@ test('iso-string-input', (t) => {
   t.end()
 })
 
+
+test('overlong-milliseconds-iso-string-input', (t) => {
+  let s = spacetime('2017-08-06T09:00:00.123456Z')
+  t.ok(s.isValid(), 'obj input is valid')
+  t.equal(s.millisecond(), 123, 'iso-string-millisecond')
+  t.equal(s.second(), 0, 'iso-string-second')
+  t.equal(s.minute(), 0, 'iso-string-minute')
+  t.equal(s.hour(), 9, 'iso-string-hour')
+  t.equal(s.date(), 6, 'iso-string-date')
+  t.equal(s.month(), 7, 'iso-string-month')
+  t.equal(s.year(), 2017, 'iso-string-year')
+  t.end()
+})
+
+
 test('iso format with space', (t) => {
   let a = spacetime('2018-02-02T22:00:00')
   let b = spacetime('2018-02-02 22:00:00')

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -145,7 +145,7 @@ test('iso-string-input', (t) => {
 
 
 test('overlong-milliseconds-iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00:00Z')
+  let s = spacetime('2017-08-06T09:00:12345Z')
   t.ok(s.isValid(), 'overlong obj input is valid')
   t.equal(s.millisecond(), 123, 'overlong-iso-string-millisecond')
   t.equal(s.second(), 0, 'overlong-iso-string-second')

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -146,7 +146,7 @@ test('iso-string-input', (t) => {
 
 test('overlong-milliseconds-iso-string-input', (t) => {
   let s = spacetime('2017-08-06T09:00:00Z')
-  t.ok(s.isValid(), 'obj input is valid')
+  t.ok(s.isValid(), 'overlong obj input is valid')
   t.equal(s.millisecond(), 123, 'overlong-iso-string-millisecond')
   t.equal(s.second(), 0, 'overlong-iso-string-second')
   t.equal(s.minute(), 0, 'overlong-iso-string-minute')

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -131,7 +131,7 @@ test('inputs-in-comparisons', (t) => {
 })
 
 test('iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00:00.000Z')
+  let s = spacetime('2017-08-06T09:00:00Z')
   t.ok(s.isValid(), 'obj input is valid')
   t.equal(s.millisecond(), 0, 'iso-string-millisecond')
   t.equal(s.second(), 0, 'iso-string-second')
@@ -145,15 +145,15 @@ test('iso-string-input', (t) => {
 
 
 test('overlong-milliseconds-iso-string-input', (t) => {
-  let s = spacetime('2017-08-06T09:00:00.123456Z')
+  let s = spacetime('2017-08-06T09:00:00Z')
   t.ok(s.isValid(), 'obj input is valid')
-  t.equal(s.millisecond(), 123, 'iso-string-millisecond')
-  t.equal(s.second(), 0, 'iso-string-second')
-  t.equal(s.minute(), 0, 'iso-string-minute')
-  t.equal(s.hour(), 9, 'iso-string-hour')
-  t.equal(s.date(), 6, 'iso-string-date')
-  t.equal(s.month(), 7, 'iso-string-month')
-  t.equal(s.year(), 2017, 'iso-string-year')
+  t.equal(s.millisecond(), 123, 'overlong-iso-string-millisecond')
+  t.equal(s.second(), 0, 'overlong-iso-string-second')
+  t.equal(s.minute(), 0, 'overlong-iso-string-minute')
+  t.equal(s.hour(), 9, 'overlong-iso-string-hour')
+  t.equal(s.date(), 6, 'overlong-iso-string-date')
+  t.equal(s.month(), 7, 'overlong-iso-string-month')
+  t.equal(s.year(), 2017, 'overlong-iso-string-year')
   t.end()
 })
 


### PR DESCRIPTION
Opening a PR to fix an issue we had in our Prod environment, where a UTC timestamp with 6-digit millisecond precision caused the spacetime date to overflow and give us a faulty date. 
e.g. 
`2017-08-06T09:00:00.123456Z`
will give 
`2017-08-06T09:00:01.234Z`