### PR TITLE
support turning off title case for i18n date formatting

### DIFF
--- a/src/data/caseFormat.js
+++ b/src/data/caseFormat.js
@@ -1,0 +1,7 @@
+let titleCaseEnabled = true
+module.exports = {
+  useTitleCase: () => titleCaseEnabled,
+  set: useTitleCase => {
+    titleCaseEnabled = useTitleCase
+  }
+}

--- a/src/fns.js
+++ b/src/fns.js
@@ -4,6 +4,7 @@ exports.isLeapYear = (year) => (year % 4 === 0 && year % 100 !== 0) || year % 40
 exports.isDate = (d) => Object.prototype.toString.call(d) === '[object Date]' && !isNaN(d.valueOf())
 exports.isArray = (input) => Object.prototype.toString.call(input) === '[object Array]'
 exports.isObject = (input) => Object.prototype.toString.call(input) === '[object Object]'
+exports.isBoolean = (input) => Object.prototype.toString.call(input) === '[object Boolean]'
 
 exports.zeroPad = (str, len = 2) => {
   let pad = '0'

--- a/src/methods/format/index.js
+++ b/src/methods/format/index.js
@@ -1,11 +1,20 @@
 const fns = require('../../fns')
 const months = require('../../data/months')
 const days = require('../../data/days')
+const caseFormat = require('../../data/caseFormat')
 const isoOffset = require('./_offset')
 
+const applyCaseFormat = (str) => {
+  if (caseFormat.useTitleCase()) {
+    return fns.titleCase(str)
+  }
+  return str
+
+}
+
 const format = {
-  day: (s) => fns.titleCase(s.dayName()),
-  'day-short': (s) => fns.titleCase(days.short()[s.day()]),
+  day: (s) => applyCaseFormat(s.dayName()),
+  'day-short': (s) => applyCaseFormat(days.short()[s.day()]),
   'day-number': (s) => s.day(),
   'day-ordinal': (s) => fns.ordinal(s.day()),
   'day-pad': (s) => fns.zeroPad(s.day()),
@@ -14,8 +23,8 @@ const format = {
   'date-ordinal': (s) => fns.ordinal(s.date()),
   'date-pad': (s) => fns.zeroPad(s.date()),
 
-  month: (s) => fns.titleCase(s.monthName()),
-  'month-short': (s) => fns.titleCase(months.short()[s.month()]),
+  month: (s) => applyCaseFormat(s.monthName()),
+  'month-short': (s) => applyCaseFormat(months.short()[s.month()]),
   'month-number': (s) => s.month(),
   'month-ordinal': (s) => fns.ordinal(s.month()),
   'month-pad': (s) => fns.zeroPad(s.month()),
@@ -100,9 +109,9 @@ const format = {
   nice: (s) => `${months.short()[s.month()]} ${fns.ordinal(s.date())}, ${s.time()}`,
   'nice-year': (s) => `${months.short()[s.month()]} ${fns.ordinal(s.date())}, ${s.year()}`,
   'nice-day': (s) =>
-    `${days.short()[s.day()]} ${fns.titleCase(months.short()[s.month()])} ${fns.ordinal(s.date())}`,
+    `${days.short()[s.day()]} ${applyCaseFormat(months.short()[s.month()])} ${fns.ordinal(s.date())}`,
   'nice-full': (s) =>
-    `${s.dayName()} ${fns.titleCase(s.monthName())} ${fns.ordinal(s.date())}, ${s.time()}`
+    `${s.dayName()} ${applyCaseFormat(s.monthName())} ${fns.ordinal(s.date())}, ${s.time()}`
 }
 //aliases
 const aliases = {
@@ -141,7 +150,7 @@ const printFormat = (s, str = '') => {
     if (str !== 'json') {
       out = String(out)
       if (str !== 'ampm') {
-        out = fns.titleCase(out)
+        out = applyCaseFormat(out)
       }
     }
     return out

--- a/src/methods/i18n.js
+++ b/src/methods/i18n.js
@@ -1,6 +1,8 @@
 const fns = require('../fns')
 const days = require('../data/days')
 const months = require('../data/months')
+const caseFormat = require('../data/caseFormat')
+
 
 const addMethods = SpaceTime => {
   const methods = {
@@ -12,6 +14,11 @@ const addMethods = SpaceTime => {
       //change the month names
       if (fns.isObject(data.months)) {
         months.set(data.months)
+      }
+
+      // change the the display style of the month / day names
+      if (fns.isBoolean(data.useTitleCase)) {
+        caseFormat.set(data.useTitleCase)
       }
     }
   }

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const spacetime = require('./lib')
 
-const defaultWords = {
+const defaultSettings = {
   days: {
     short: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
     long: ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
@@ -22,8 +22,53 @@ const defaultWords = {
       'november',
       'december'
     ]
-  }
+  }, 
+  useTitleCase: true
 }
+
+test('i18n useTitleCase is false', (t) => {
+  let a = spacetime([2000, 0, 1])
+
+  t.equal(a.format('day-short'), 'Sat', 'en: day-short')
+  t.equal(a.format('day'), 'Saturday', 'en: day')
+  t.equal(a.format('month-short'), 'Jan', 'en: month-short')
+  t.equal(a.format('month'), 'January', 'en: month')
+
+  a.i18n({
+    days: {
+      short: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
+      long: ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado']
+    },
+    months: {
+      short: ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'],
+      long: [
+        'enero',
+        'febrero',
+        'marzo',
+        'abril',
+        'mayo',
+        'junio',
+        'julio',
+        'agosto',
+        'septiembre',
+        'octubre',
+        'noviembre',
+        'diciembre'
+      ]
+    },
+    useTitleCase: false
+  })
+
+  t.equal(a.format('day-short'), 'sáb', 'es: day-short lowercase')
+  t.equal(a.format('day'), 'sábado', 'es: day lowercase')
+  t.equal(a.format('month-short'), 'ene', 'es: month-short lowercase')
+  t.equal(a.format('month'), 'enero', 'es: month lowercase')
+
+  //reset them, for the other tests
+  a.i18n(defaultSettings)
+
+  t.end()
+})
 
 test('i18n', (t) => {
   let a = spacetime([2000, 0, 1])
@@ -63,7 +108,7 @@ test('i18n', (t) => {
   t.equal(a.format('month'), 'Enero', 'es: month')
 
   //reset them, for the other tests
-  a.i18n(defaultWords)
+  a.i18n(defaultSettings)
 
   t.end()
 })


### PR DESCRIPTION
This PR adds a param `useTitleCase` that can be set as part of `i18n` to turn off the default behavior of returning the day / month names in title case. 

This helps to fully support internationalizing with local date formats -- ex: ex: in French and Spanish, day / month names are typically displayed in  lowercase.

added test case to confirm when `useTitleCase` is set to false, day & month names are all as entered (lower case)