### PR TITLE
#255 Added dmy? to SpacetimeConstructorOptions type definitions

### DIFF
--- a/types/constructors.d.ts
+++ b/types/constructors.d.ts
@@ -6,6 +6,9 @@ export interface SpacetimeConstructorOptions {
 
   /** the day number, between 0-6, that the week starts on. (Sunday is 0) */
   weekStart?: number
+
+  /** pass true to change parsing behaviour to dd/mm/yyyy. By default American interpretation will be used. */
+  dmy?: boolean
 }
 
 export interface SpacetimeConstructor {


### PR DESCRIPTION
Quick fix for #255 . I am new to spacetime so I don´t know if anything else is missing here but that is one option I recognized when I tried to use. 