### PR TITLE
Match caseformat with curly bracket notation and add nice 24h formats

### DIFF
--- a/src/methods/format/index.js
+++ b/src/methods/format/index.js
@@ -161,7 +161,11 @@ const printFormat = (s, str = '') => {
     str = str.replace(sections, (_, fmt) => {
       fmt = fmt.toLowerCase().trim()
       if (format.hasOwnProperty(fmt)) {
-        return String(format[fmt](s))
+        let out = String(format[fmt](s))
+        if (fmt !== 'ampm') {
+          return applyCaseFormat(out)
+        }
+        return out
       }
       return ''
     })

--- a/src/methods/format/index.js
+++ b/src/methods/format/index.js
@@ -107,11 +107,14 @@ const format = {
 
   //i made these up
   nice: (s) => `${months.short()[s.month()]} ${fns.ordinal(s.date())}, ${s.time()}`,
+  'nice-24': (s) => `${months.short()[s.month()]} ${fns.ordinal(s.date())}, ${s.hour24()}:${fns.zeroPad(s.minute())}`,
   'nice-year': (s) => `${months.short()[s.month()]} ${fns.ordinal(s.date())}, ${s.year()}`,
   'nice-day': (s) =>
     `${days.short()[s.day()]} ${applyCaseFormat(months.short()[s.month()])} ${fns.ordinal(s.date())}`,
   'nice-full': (s) =>
-    `${s.dayName()} ${applyCaseFormat(s.monthName())} ${fns.ordinal(s.date())}, ${s.time()}`
+    `${s.dayName()} ${applyCaseFormat(s.monthName())} ${fns.ordinal(s.date())}, ${s.time()}`,
+  'nice-full-24': (s) =>
+    `${s.dayName()} ${applyCaseFormat(s.monthName())} ${fns.ordinal(s.date())}, ${s.hour24()}:${fns.zeroPad(s.minute())}`
 }
 //aliases
 const aliases = {
@@ -127,6 +130,7 @@ const aliases = {
   'month-iso': 'iso-month',
   'year-iso': 'iso-year',
   'nice-short': 'nice',
+  'nice-short-24': 'nice-24',
   mdy: 'numeric-us',
   dmy: 'numeric-uk',
   ymd: 'numeric',


### PR DESCRIPTION
I noticed that when using curly bracket formats such as `"{day-short} {date-ordinal} {month-short}"` none of the words where capitalized. I added that functionally to `.format()` based on the code above.

I also quickly added 24h versions of the nice and nice-full formats, which I would like to use in one of my sites.

I tested what I changed in a test build as I'm not yet fully sure how to properly write tests and didn't want to make a mess :')
![Screenshot_20210102_144953](https://user-images.githubusercontent.com/19474909/103458657-8a493f80-4d0a-11eb-8342-48c548f107a4.png)

For Comparison this is the current behaviour for curly brackets as of 6.12.2rc:
![Screenshot_20210102_145616](https://user-images.githubusercontent.com/19474909/103458670-ad73ef00-4d0a-11eb-8c93-3515c4bae54d.png)
