### PR TITLE
Allow `goto` to accept `null`

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -21,7 +21,7 @@ export interface Spacetime {
   timezones: TimezoneSet
 
   /** move to a new timezone, but at this same moment. Accepts an IANA code or abbreviation */
-  goto: (target: string) => Spacetime
+  goto: (target: string | null) => Spacetime
 
   /** @returns a copy of this object, with no references to the original */
   clone: () => Spacetime


### PR DESCRIPTION
Currently the documentation here: https://github.com/spencermountain/spacetime#timezones specifies that we should be allowed to pass `null` into `Spacetime.goto`, the types do not support this. This commit allows the types to accept a `null` parameter into `Spacetime.goto`