### PR TITLE
Add feature to format milliseconds

### DIFF
--- a/src/methods/format/index.js
+++ b/src/methods/format/index.js
@@ -70,6 +70,8 @@ const format = {
   'minute-pad': (s) => fns.zeroPad(s.minute()),
   second: (s) => s.second(),
   'second-pad': (s) => fns.zeroPad(s.second()),
+  millisecond: (s)=> s.millisecond(),
+  'millisecond-pad': (s)=> fns.zeroPad(s.millisecond(),3),
 
   ampm: (s) => s.ampm(),
   quarter: (s) => 'Q' + s.quarter(),

--- a/src/methods/format/unixFmt.js
+++ b/src/methods/format/unixFmt.js
@@ -78,6 +78,9 @@ const mapping = {
   mm: (s) => pad(s.minute()),
   s: (s) => s.second(),
   ss: (s) => pad(s.second()),
+
+  //milliseconds
+  SSS: (s)=>pad(s.millisecond(),3),
   //milliseconds in the day
   A: (s) => s.epoch - s.startOf('day').epoch,
   //timezone

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -154,6 +154,13 @@ test('offset formatting', (t) => {
   t.end()
 })
 
+test('test millisecond', (t)=>{
+  const date = spacetime('1990-03-22T06:20:30.020+11:30')
+  t.equal(date.format('millisecond'),'20','Millisecond in format')
+  t.equal(date.format('millisecond-pad'),'020','Millisecond with pad in format')
+  t.equal(date.unixFmt('SSS'),'020','Millisecond with pad in unix')
+  t.end()
+})
 /* FIXME failing test
 test('unix-fmt-padding', t => {
   let d = spacetime({

--- a/types/constraints.d.ts
+++ b/types/constraints.d.ts
@@ -40,6 +40,7 @@ export type Format =
   | 'minute-pad'
   | 'second'
   | 'second-pad'
+  | 'millisecond'
   | 'ampm'
   | 'quarter'
   | 'season'


### PR DESCRIPTION
Add 'millisecond' and 'millisecond-pad' for format(),
Add 'SSS' which means millisecond with pad for unixfmt()