### PR TITLE
fix: update `asia/baku` default offset

### DIFF
--- a/zonefile/iana.js
+++ b/zonefile/iana.js
@@ -909,7 +909,7 @@ module.exports = {
     hem: 'n'
   },
   'asia/baku': {
-    offset: 5,
+    offset: 4,
     hem: 'n'
   },
   'asia/bangkok': {


### PR DESCRIPTION
Baku changed from `GMT+5:00` to `GMT+4:00` a few years ago.

See the last entry in the timeline at the bottom of: https://timezonedb.com/time-zones/Asia/Baku

Was brought to my attention by a user in an issue on my react-timezone-select component (https://github.com/ndom91/react-timezone-select/issues/33)