### PR TITLE
Update naming of 'day' unit to 'date'. Fixes #296.

### DIFF
--- a/src/methods/add.js
+++ b/src/methods/add.js
@@ -34,7 +34,7 @@ const dstAwareUnits = {
   season: true,
   month: true,
   week: true,
-  day: true
+  date: true
 }
 
 const keepDate = {

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -106,6 +106,10 @@ test('day-tricky', (t) => {
   d = d.add(7, 'days')
   t.equal(d.format('nice-day'), 'Mon Nov 11th', 'add days over dst-change')
 
+  d = spacetime('2021-10-31T00:00:00.000', 'Europe/London')
+  d = d.add(1, 'day')
+  t.equal(d.format('iso-utc'), '2021-11-01T00:00:00.000Z', 'add 1 day over dst-change')
+
   // add day over month-change
   let s = spacetime('Oct 31 2020', 'Canada/Eastern')
   s = s.add(2, 'day')


### PR DESCRIPTION
I initially assumed this bug was down to a more complex issue around DST changes, but it turned out to be caused just by a naming inconsistency between `day` and `date`. 

I'm not sure what the history of "date" vs "day" for the unit name is, but certainly in terms of *intervals*, "day" does make more sense, and I can see why the code that caused this bug *looked* correct. 