### PR TITLE
Format function type should only return string

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -39,7 +39,7 @@ export interface Spacetime {
   timezone: () => TimezoneMeta
 
   /** output nicely-formatted strings */
-  format: (format: Format) => string | object
+  format: (format: Format) => string
 
   /** output formatted string using unix formatting code (yyyy.MM.dd h:mm a) */
   unixFmt: (format: string) => string


### PR DESCRIPTION
I _think_ this is correct? Didn't see how an object would be returned in the source and the docs. comment on the above line suggest it's only string.