### PR TITLE
Beesley/i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,10 @@ a.i18n({
     long: [...],
     short: ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'],
   },
+  ampm: {
+    am: ' a. m.',
+    pm: ' a. m.'
+  },
   useTitleCase: true // automatically in .format()
 });
 a.format('day') //'Sábado'

--- a/src/data/ampm.js
+++ b/src/data/ampm.js
@@ -1,0 +1,9 @@
+let morning = 'am'
+let evening = 'pm'
+
+export function am() { return morning }
+export function pm() { return evening }
+export function set(i18n) {
+    morning = i18n.am || morning
+    evening = i18n.pm || evening
+}

--- a/src/methods/i18n.js
+++ b/src/methods/i18n.js
@@ -1,7 +1,8 @@
 import { isObject, isBoolean } from '../fns.js'
-import { set } from '../data/days.js'
-import { set as _set } from '../data/months.js'
-import { set as __set } from '../data/caseFormat.js'
+import { set as setD } from '../data/days.js'
+import { set as setM } from '../data/months.js'
+import { set as setTcf } from '../data/caseFormat.js'
+import { set as setAmpm} from '../data/ampm.js'
 
 
 const addMethods = SpaceTime => {
@@ -9,16 +10,21 @@ const addMethods = SpaceTime => {
     i18n: data => {
       //change the day names
       if (isObject(data.days)) {
-        set(data.days)
+        setD(data.days)
       }
       //change the month names
       if (isObject(data.months)) {
-        _set(data.months)
+        setM(data.months)
       }
 
       // change the the display style of the month / day names
       if (isBoolean(data.useTitleCase)) {
-        __set(data.useTitleCase)
+        setTcf(data.useTitleCase)
+      }
+
+      //change am and pm strings
+      if (isObject(data.ampm)) {
+        setAmpm(data.ampm)
       }
     }
   }

--- a/src/methods/query/01-time.js
+++ b/src/methods/query/01-time.js
@@ -1,4 +1,5 @@
 import { milliseconds, seconds, minutes, hours, time as _time } from '../set/set.js'
+import { am, pm } from '../../data/ampm.js'
 import { zeroPad } from '../../fns.js'
 
 const methods = {
@@ -94,10 +95,12 @@ const methods = {
 
   // either 'am' or 'pm'
   ampm: function (input, goFwd) {
-    let which = 'am'
+    // let which = 'am'
+    let which = am()
     let hour = this.hour()
     if (hour >= 12) {
-      which = 'pm'
+      // which = 'pm'
+      which = pm()
     }
     if (typeof input !== 'string') {
       return which

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -116,7 +116,6 @@ test('i18n', (t) => {
   t.equal(a.format('month'), 'Enero', 'es: month')
 
   t.equal(a.format('time'), '12:00 a. m.', 'es: am')
-  console.log('A => ', a.format('time'))
 
   //reset them, for the other tests
   a.i18n(defaultSettings)

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -23,7 +23,11 @@ const defaultSettings = {
       'december'
     ]
   },
-  useTitleCase: true
+  useTitleCase: true,
+  ampm: {
+    am: 'am',
+    pm: 'pm'
+  }
 }
 
 test('i18n useTitleCase is false', (t) => {
@@ -99,6 +103,10 @@ test('i18n', (t) => {
         'noviembre',
         'diciembre'
       ]
+    },
+      ampm: {
+        am: ' a. m.',
+        pm: ' p. m.'
     }
   })
 
@@ -106,6 +114,9 @@ test('i18n', (t) => {
   t.equal(a.format('day'), 'Sábado', 'es: day')
   t.equal(a.format('month-short'), 'Ene', 'es: month-short')
   t.equal(a.format('month'), 'Enero', 'es: month')
+
+  t.equal(a.format('time'), '12:00 a. m.', 'es: am')
+  console.log('A => ', a.format('time'))
 
   //reset them, for the other tests
   a.i18n(defaultSettings)


### PR DESCRIPTION
Hoping to contribute as a follow-up to issue #145 regarding hard-coded strings. I followed the existing pattern used to internationalize the months and days and added an ampm.js file to update the 'am' and 'pm' strings if passed in to i18n. I also updated the i18n test and the README.

Note: certain languages may need more complex options depending on time of day.

Any feedback is very welcome. Thanks!