### PR TITLE
fix issue #306: embed the link into the GitHub icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body>
   <a class="topright" href="https://github.com/smallwins/spacetime">
     github
-    <img src="./assets/github.png" style="width:15px;" alt="github"/>
+    <img src="./assets/github.png" style="width:15px;" href="https://github.com/smallwins/spacetime" alt="github"/>
   </a>
   <div class="nice big">
     Yeah,


### PR DESCRIPTION
Decided to work on issue #306 
Embedded a link into the Github icon on the website so users can also press the image to lead them to the github repo