### PR TITLE
Update constructors.d.ts - allow optionally undefined ParsableDate

### DIFF
--- a/types/constructors.d.ts
+++ b/types/constructors.d.ts
@@ -54,7 +54,7 @@ export interface SpacetimeConstructor {
    * @param timezone Optional timezone. If omitted uses the browser timezone.
    * @param options Options for silencing warnings.
    */
-  (parsableDate?: ParsableDate, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
+  (parsableDate?: ParsableDate | null, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
 }
 
 export interface SpacetimeStatic extends SpacetimeConstructor {

--- a/types/constructors.d.ts
+++ b/types/constructors.d.ts
@@ -54,7 +54,7 @@ export interface SpacetimeConstructor {
    * @param timezone Optional timezone. If omitted uses the browser timezone.
    * @param options Options for silencing warnings.
    */
-  (parsableDate: ParsableDate, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
+  (parsableDate?: ParsableDate, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
 }
 
 export interface SpacetimeStatic extends SpacetimeConstructor {

--- a/types/constructors.d.ts
+++ b/types/constructors.d.ts
@@ -13,13 +13,6 @@ export interface SpacetimeConstructorOptions {
 
 export interface SpacetimeConstructor {
   /**
-   * @param date Javascript date object
-   * @param timezone Optional timezone. If omitted uses the browser timezone.
-   * @param options Options for silencing warnings.
-   */
-  (date?: Date, timezone?: string, options?: SpacetimeConstructorOptions): Spacetime
-
-  /**
    * @param epoch Timestamp in **milliseconds**. If you are getting a date in 1970, you are likely using seconds.
    * @param timezone Optional timezone. If omitted uses the browser timezone.
    * @param options Options for silencing warnings.


### PR DESCRIPTION
currently, if you have a type that is one of the `ParsableDate` and optionally undefined, but not specifically a `Date` or undefined (i.e. `Date | undefined`) typescript will not allow the ParsableDate constructor as it does not allow undefined:

```ts
setDate(date?: string) {
  const st = spacetime(date)
}
```
> No overload matches this call.
  The last overload gave the following error.
    Argument of type 'string | undefined' is not assignable to parameter of type 'ParsableDate'.

This PR removes one of the constructors (that is already covered by the ParsableDate constructor), and allows ParsableDate to be undefined