### PR TITLE
Fix iana timezones of mexico

### DIFF
--- a/zonefile/iana.js
+++ b/zonefile/iana.js
@@ -254,7 +254,7 @@ export default {
     "hem": "n"
   },
   "america/bahia_banderas": {
-    "offset": -5,
+    "offset": -6,
     "hem": "n",
   },
   "america/barbados": {
@@ -543,7 +543,7 @@ export default {
     "dst": "03/12:02->11/05:02"
   },
   "america/mazatlan": {
-    "offset": -6,
+    "offset": -7,
     "hem": "n"
   },
   "america/mendoza": {
@@ -556,7 +556,7 @@ export default {
     "dst": "03/12:02->11/05:02"
   },
   "america/merida": {
-    "offset": -5,
+    "offset": -6,
     "hem": "n"
   },
   "america/metlakatla": {
@@ -565,7 +565,7 @@ export default {
     "dst": "03/12:02->11/05:02"
   },
   "america/mexico_city": {
-    "offset": -5,
+    "offset": -6,
     "hem": "n"
   },
   "america/miquelon": {
@@ -579,7 +579,7 @@ export default {
     "dst": "03/12:02->11/05:02"
   },
   "america/monterrey": {
-    "offset": -5,
+    "offset": -6,
     "hem": "n",
   },
   "america/montevideo": {


### PR DESCRIPTION
Mexico removed the DST for most of their timezones last year. [Approved law on 28/10/2022](https://www.dof.gob.mx/nota_detalle.php?codigo=5670045&fecha=28/10/2022)

This PR updates the `iana.js` file with the updated offsets of the iana database 2023c revision.