### PR TITLE
fix types resolution for node16 / bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./builds/spacetime.cjs",
       "import": "./src/index.js"
     }


### PR DESCRIPTION
If `nodeResolution` in `tsconfig.json` is set to `Node16` `NodeNext` or `Bundler`, TypeScript (tested on version 5.1.6) will throw error:

```
import spacetime from 'spacetime';
```

```
'spacetime' is declared but its value is never read.ts(6133)
Could not find a declaration file for module 'spacetime'. 
```