### PR TITLE
Add stepCount parameter for every()

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -103,14 +103,14 @@ const methods = {
     return s
   },
   //get each week/month/day between a -> b
-  every: function (unit, to) {
+  every: function (unit, to, stepCount) {
     // allow swapping these params:
     if (typeof unit === 'object' && typeof to === 'string') {
       let tmp = to
       to = unit
       unit = tmp
     }
-    return every(this, unit, to)
+    return every(this, unit, to, stepCount)
   },
   isAwake: function () {
     let hour = this.hour()

--- a/src/methods/every.js
+++ b/src/methods/every.js
@@ -14,7 +14,7 @@ const isDay = function (unit) {
 
 // return a list of the weeks/months/days between a -> b
 // returns spacetime objects in the timezone of the input
-const every = function (start, unit, end) {
+const every = function (start, unit, end, stepCount = 1) {
   if (!unit || !end) {
     return []
   }
@@ -44,7 +44,7 @@ const every = function (start, unit, end) {
   let result = []
   while (d.isBefore(end)) {
     result.push(d)
-    d = d.add(1, unit)
+    d = d.add(stepCount, unit)
   }
   return result
 }

--- a/src/methods/every.js
+++ b/src/methods/every.js
@@ -28,7 +28,10 @@ const every = function (start, unit, end, stepCount = 1) {
     start = end
     end = tmp
   }
-
+  //prevent going beyond end if unit/stepCount > than the range
+  if (start.diff(end, unit) < stepCount) {
+    return []
+  }
   //support 'every wednesday'
   let d = start.clone()
   if (isDay(unit)) {

--- a/test/every.test.js
+++ b/test/every.test.js
@@ -18,6 +18,25 @@ test('every-unit', (t) => {
   t.end()
 })
 
+test('step-count', (t) => {
+  let start = spacetime('April 6th 2019', 'Europe/Paris')
+  let end = spacetime('April 20th 2019', 'Europe/Paris').add(3, 'years')
+
+  let biannualInterval = start.every('quarter', end, 2)
+  t.equal(biannualInterval.length, 6, 'every 2 quarters')
+  t.equal(biannualInterval[0].timezone().name, 'Europe/Paris', 'results in right timezone')
+
+  let fortnights = start.every('week', end, 2)
+  t.equal(fortnights.length, 80, 'every fortnight')
+  t.equal(biannualInterval[0].timezone().name, 'Europe/Paris', 'results in right timezone')
+
+  let everyFourYears = start.every('years', end, 4)
+  t.equal(everyFourYears.length, 1, 'every four years')
+  t.equal(everyFourYears[0].timezone().name, 'Europe/Paris', 'results in right timezone')
+
+  t.end()
+})
+
 test('monday-sunday', (t) => {
   let days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
   let start = spacetime('April 8th 2019').startOf('week')

--- a/test/every.test.js
+++ b/test/every.test.js
@@ -31,8 +31,7 @@ test('step-count', (t) => {
   t.equal(biannualInterval[0].timezone().name, 'Europe/Paris', 'results in right timezone')
 
   let everyFourYears = start.every('years', end, 4)
-  t.equal(everyFourYears.length, 1, 'every four years')
-  t.equal(everyFourYears[0].timezone().name, 'Europe/Paris', 'results in right timezone')
+  t.equal(everyFourYears.length, 0, 'interval/step count too large for range')
 
   t.end()
 })

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -66,7 +66,7 @@ export interface Spacetime {
   round: (unit: TimeUnit) => Spacetime
 
   /** list all dates up to a certain time */
-  every: (unit: Spacetime | string | TimeUnit, end: Spacetime | string | TimeUnit) => Spacetime[]
+  every: (unit: Spacetime | string | TimeUnit, end: Spacetime | string | TimeUnit, stepCount: number) => Spacetime[]
 
   /** list all dates up to a certain time */
   each: (unit: TimeUnit, end: Spacetime | string) => Spacetime[]


### PR DESCRIPTION
👋 Thanks for taking the time to look at this!

This PR adds a `stepCount` parameter to the `.every()` function, which defaults to 1. 

This is practical for a variety of intervals:
- biannual: every 6 months / 2 quarters
- every 2 weeks
- every 4 years
- every 90 minutes

Happy to address any feedback!