### PR TITLE
Fix AMPM formatting casing.

### DIFF
--- a/src/methods/format/index.js
+++ b/src/methods/format/index.js
@@ -183,7 +183,10 @@ const printFormat = (s, str = '') => {
   if (str.indexOf('{') !== -1) {
     let sections = /\{(.+?)\}/g
     str = str.replace(sections, (_, fmt) => {
-      fmt = fmt.toLowerCase().trim()
+      fmt = fmt.trim()
+      if (fmt !== 'AMPM') {
+        fmt = fmt.toLowerCase()
+      }
       if (format.hasOwnProperty(fmt)) {
         let out = String(format[fmt](s))
         if (fmt.toLowerCase() !== 'ampm') {

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -186,4 +186,20 @@ test('unix-year-padding', t => {
   s = spacetime('sep 1 2000')
   t.equal(s.unixFmt('yy'), '00', 'zero-end')
   t.end()
-});
+})
+
+test('am-pm-variants', (t) => {
+  let s = spacetime('January 1, 2023')
+  s = s.time('4:45pm')
+  let arr = [
+    ['{hour}:{minute}{ampm}', '4:45pm'],
+    ['{hour}:{minute}{AMPM}', '4:45PM'],
+    ['{hour}:{minute}{AMPM }', '4:45PM'],
+    ['{AMPM}', 'PM'],
+  ]
+  arr.forEach((a) => {
+    t.equal(s.format(a[0]), a[1], a[2], a[3])
+  })
+  t.end()
+})
+  


### PR DESCRIPTION
Fixes issue https://github.com/spencermountain/spacetime/issues/414

The formatting function automatically casts the format to lower case, so a format of `AMPM` is always evaluated as `ampm`. This conditionally casts to lowercase if the format is not `AMPM`