### PR TITLE
Fixes type issues here https://arethetypeswrong.github.io/

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./types/index.d.ts",
-      "require": "./builds/spacetime.cjs",
-      "import": "./src/index.js"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./builds/spacetime.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./builds/spacetime.cjs"
+      }
     }
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ export default [
   {
     input: 'src/index.js',
     output: [{ banner: banner, file: 'builds/spacetime.mjs', format: 'esm' }],
-    plugins: [resolve(), json(), commonjs(), terser(), sizeCheck({ expect: 48, warn: 10 })]
+    plugins: [resolve(), json(), terser(), sizeCheck({ expect: 48, warn: 10 })]
   },
   {
     input: 'src/index.js',


### PR DESCRIPTION
I looked into your comment on https://github.com/spencermountain/spacetime/pull/427

The issues that the site complained about were https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md and https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md

To fix this I broke out the export types so CommonJS and ECMA have their own config. The index.d.cts file is the CommonJS input for the typings. TypeScript will automatically pick the preferred one based on what users select in their own config. Here's a gist of the ECMA version

https://gist.github.com/jecraig/0d50ee704409ddb1bb47d8f4371c9315

And of the CommonJS version

https://gist.github.com/jecraig/58010cef8df4083312cbb44f79ad3605

You can run them both by

npm install
npx tsc && node index.js

This did cause a breaking change on my main project but it was easily fixed by updating my type only imports to be explicitly type only 

```
Broken
import spacetime, { Format } from 'spacetime';

Fixed
import spacetime, { type Format } from 'spacetime';
```

The reason for this is that TypeScript was looking for an actual export from the mjs file called Format but that doesn't exist as it only exports the default spacetime object. So a quick fix but definitely something we may want to call out in the release notes.

I did remove the commonJS() plugin in Rollup for the mjs build as it won't be used for CommonJS builds but I'll let you make that call. 