### PR TITLE
Fix parseLine in updateZoneFile.js to properly detect isdst=1 + update dst data

### DIFF
--- a/scripts/updateZonefile.js
+++ b/scripts/updateZonefile.js
@@ -35,7 +35,7 @@ const parseLine = (line) => {
   let arr = line.split(/ +/)
   let hour = arr[11].replace(/:[0-9:]+/, '')
   let min = arr[11].replace(/[0-9]{1,2}:([0-9]+):/, '$1')
-  let dst = arr[arr.length - 1] === 'isdst=1'
+  let dst = line.includes('isdst=1')
   hour = parseInt(hour, 10)
   if (min === '0000' && dst === true) {
     hour -= 1

--- a/zonefile/iana.js
+++ b/zonefile/iana.js
@@ -54,17 +54,17 @@ export default {
   'africa/cairo': {
     offset: 3,
     hem: 'n',
-    'dst': '04/25:02->10/30:24'
+    'dst': '04/25:00->10/30:24'
   },
   'africa/casablanca': {
     offset: 0,
     hem: 's',
-    'dst': '02/23:03->04/06:04'
+    'dst': '02/23:03->04/06:02'
   },
   'africa/ceuta': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'africa/conakry': {
     offset: 0,
@@ -89,7 +89,7 @@ export default {
   'africa/el_aaiun': {
     offset: 0,
     hem: 's',
-    'dst': '02/23:03->04/06:04'
+    'dst': '02/23:03->04/06:02'
   },
   'africa/freetown': {
     offset: 0,
@@ -218,12 +218,12 @@ export default {
   'america/adak': {
     offset: -9,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/anchorage': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/anguilla': {
     offset: -4,
@@ -285,7 +285,7 @@ export default {
   'america/boise': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/buenos_aires': {
     offset: -3,
@@ -294,7 +294,7 @@ export default {
   'america/cambridge_bay': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/campo_grande': {
     offset: -4,
@@ -323,7 +323,7 @@ export default {
   'america/chicago': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/chihuahua': {
     offset: -6,
@@ -368,12 +368,12 @@ export default {
   'america/denver': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/detroit': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/dominica': {
     offset: -4,
@@ -382,7 +382,7 @@ export default {
   'america/edmonton': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/eirunepe': {
     offset: -5,
@@ -403,22 +403,22 @@ export default {
   'america/glace_bay': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/nuuk': {
     offset: -1,
     hem: 'n',
-    'dst': '03/30:01->10/25:24'
+    'dst': '03/30:-1->10/25:24'
   },
   'america/goose_bay': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/grand_turk': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/grenada': {
     offset: -4,
@@ -443,12 +443,12 @@ export default {
   'america/halifax': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/havana': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:02->11/02:01'
+    'dst': '03/09:00->11/02:01'
   },
   'america/hermosillo': {
     offset: -7,
@@ -462,17 +462,17 @@ export default {
   'america/indianapolis': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/inuvik': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/iqaluit': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/jamaica': {
     offset: -5,
@@ -485,7 +485,7 @@ export default {
   'america/juneau': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/kentucky': {
     offset: -4,
@@ -507,12 +507,12 @@ export default {
   'america/los_angeles': {
     offset: -7,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/louisville': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/lower_princes': {
     offset: -4,
@@ -541,7 +541,7 @@ export default {
   'america/matamoros': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/mazatlan': {
     offset: -7,
@@ -554,7 +554,7 @@ export default {
   'america/menominee': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/merida': {
     offset: -6,
@@ -564,7 +564,7 @@ export default {
   'america/metlakatla': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/mexico_city': {
     offset: -6,
@@ -573,12 +573,12 @@ export default {
   'america/miquelon': {
     offset: -2,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/moncton': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/monterrey': {
     offset: -6,
@@ -591,7 +591,7 @@ export default {
   'america/montreal': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/montserrat': {
     offset: -4,
@@ -600,22 +600,22 @@ export default {
   'america/nassau': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/new_york': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/nipigon': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/nome': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/noronha': {
     offset: -2,
@@ -629,12 +629,12 @@ export default {
   'america/ojinaga': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/ciudad_juarez': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/panama': {
     offset: -5,
@@ -643,7 +643,7 @@ export default {
   'america/pangnirtung': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/paramaribo': {
     offset: -3,
@@ -656,7 +656,7 @@ export default {
   'america/port-au-prince': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/port_of_spain': {
     offset: -4,
@@ -677,12 +677,12 @@ export default {
   'america/rainy_river': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/rankin_inlet': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/recife': {
     offset: -3,
@@ -695,7 +695,7 @@ export default {
   'america/resolute': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/rio_branco': {
     offset: -5,
@@ -704,7 +704,7 @@ export default {
   'america/santa_isabel': {
     offset: -7,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/santarem': {
     offset: -3,
@@ -713,7 +713,7 @@ export default {
   'america/santiago': {
     offset: -4,
     hem: 's',
-    'dst': '04/05:24->09/07:02'
+    'dst': '04/05:24->09/07:00'
   },
   'america/santo_domingo': {
     offset: -4,
@@ -726,12 +726,12 @@ export default {
   'america/scoresbysund': {
     offset: 0,
     hem: 'n',
-    'dst': '03/30:01->10/25:24'
+    'dst': '03/30:-1->10/25:24'
   },
   'america/sitka': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/st_barthelemy': {
     offset: -4,
@@ -740,7 +740,7 @@ export default {
   'america/st_johns': {
     offset: -2.5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/st_kitts': {
     offset: -4,
@@ -769,22 +769,22 @@ export default {
   'america/thule': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/thunder_bay': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/tijuana': {
     offset: -7,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/toronto': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/tortola': {
     offset: -4,
@@ -793,7 +793,7 @@ export default {
   'america/vancouver': {
     offset: -7,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/whitehorse': {
     offset: -7,
@@ -802,17 +802,17 @@ export default {
   'america/winnipeg': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/yakutat': {
     offset: -8,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/yellowknife': {
     offset: -6,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'antarctica/casey': {
     offset: 8,
@@ -830,7 +830,7 @@ export default {
   'antarctica/macquarie': {
     offset: 11,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'antarctica/mawson': {
     offset: 5,
@@ -839,7 +839,7 @@ export default {
   'antarctica/mcmurdo': {
     offset: 12,
     hem: 's',
-    'dst': '04/06:03->09/28:04'
+    'dst': '04/06:03->09/28:02'
   },
   'antarctica/palmer': {
     offset: -3,
@@ -856,7 +856,7 @@ export default {
   'antarctica/troll': {
     offset: 2,
     hem: 's',
-    'dst': '03/30:04->10/26:02'
+    'dst': '03/30:02->10/26:02'
   },
   'antarctica/vostok': {
     offset: 6,
@@ -865,7 +865,7 @@ export default {
   'arctic/longyearbyen': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'asia/aden': {
     offset: 3,
@@ -922,7 +922,7 @@ export default {
   'asia/beirut': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:02->10/25:24'
+    'dst': '03/30:00->10/25:24'
   },
   'asia/bishkek': {
     offset: 6,
@@ -967,17 +967,17 @@ export default {
   'asia/famagusta': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'asia/gaza': {
     offset: 3,
     hem: 'n',
-    'dst': '04/12:04->10/25:02'
+    'dst': '04/12:02->10/25:02'
   },
   'asia/hebron': {
     offset: 3,
     hem: 'n',
-    'dst': '04/12:04->10/25:02'
+    'dst': '04/12:02->10/25:02'
   },
   'asia/hong_kong': {
     offset: 8,
@@ -1002,7 +1002,7 @@ export default {
   'asia/jerusalem': {
     offset: 3,
     hem: 'n',
-    'dst': '03/28:04->10/26:02'
+    'dst': '03/28:02->10/26:02'
   },
   'asia/kabul': {
     offset: 4.5,
@@ -1063,7 +1063,7 @@ export default {
   'asia/nicosia': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'asia/novokuznetsk': {
     offset: 7,
@@ -1204,17 +1204,17 @@ export default {
   'atlantic/azores': {
     offset: 0,
     hem: 'n',
-    'dst': '03/30:02->10/26:01'
+    'dst': '03/30:00->10/26:01'
   },
   'atlantic/bermuda': {
     offset: -3,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'atlantic/canary': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'atlantic/cape_verde': {
     offset: -1,
@@ -1223,12 +1223,12 @@ export default {
   'atlantic/faroe': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'atlantic/madeira': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'atlantic/reykjavik': {
     offset: 0,
@@ -1249,7 +1249,7 @@ export default {
   'australia/adelaide': {
     offset: 9.5,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'australia/brisbane': {
     offset: 10,
@@ -1258,12 +1258,12 @@ export default {
   'australia/broken_hill': {
     offset: 9.5,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'australia/currie': {
     offset: 10,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'australia/darwin': {
     offset: 9.5,
@@ -1276,7 +1276,7 @@ export default {
   'australia/hobart': {
     offset: 10,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'australia/lindeman': {
     offset: 10,
@@ -1290,7 +1290,7 @@ export default {
   'australia/melbourne': {
     offset: 10,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'australia/perth': {
     offset: 8,
@@ -1299,17 +1299,17 @@ export default {
   'australia/sydney': {
     offset: 10,
     hem: 's',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'europe/amsterdam': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/andorra': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/astrakhan': {
     offset: 4,
@@ -1318,77 +1318,77 @@ export default {
   'europe/athens': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/belgrade': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/berlin': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/bratislava': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/brussels': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/bucharest': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/budapest': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/busingen': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/chisinau': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/copenhagen': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/dublin': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/gibraltar': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/guernsey': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/helsinki': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/isle_of_man': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/istanbul': {
     offset: 3,
@@ -1397,7 +1397,7 @@ export default {
   'europe/jersey': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/kaliningrad': {
     offset: 2,
@@ -1410,42 +1410,42 @@ export default {
   'europe/kyiv': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/lisbon': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/ljubljana': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/london': {
     offset: 1,
     hem: 'n',
-    'dst': '03/30:03->10/26:02'
+    'dst': '03/30:01->10/26:02'
   },
   'europe/luxembourg': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/madrid': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/malta': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/mariehamn': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/minsk': {
     offset: 3,
@@ -1454,7 +1454,7 @@ export default {
   'europe/monaco': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/moscow': {
     offset: 3,
@@ -1463,32 +1463,32 @@ export default {
   'europe/oslo': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/paris': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/podgorica': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/prague': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/riga': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/rome': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/samara': {
     offset: 4,
@@ -1501,12 +1501,12 @@ export default {
   'europe/san_marino': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/sarajevo': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/simferopol': {
     offset: 3,
@@ -1515,27 +1515,27 @@ export default {
   'europe/skopje': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/sofia': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/stockholm': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/tallinn': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/tirane': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/ulyanovsk': {
     offset: 4,
@@ -1544,27 +1544,27 @@ export default {
   'europe/uzhgorod': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/vaduz': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/vatican': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/vienna': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/vilnius': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/volgograd': {
     offset: 4,
@@ -1573,22 +1573,22 @@ export default {
   'europe/warsaw': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/zagreb': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'europe/zaporozhye': {
     offset: 3,
     hem: 'n',
-    'dst': '03/30:05->10/26:04'
+    'dst': '03/30:03->10/26:04'
   },
   'europe/zurich': {
     offset: 2,
     hem: 'n',
-    'dst': '03/30:04->10/26:03'
+    'dst': '03/30:02->10/26:03'
   },
   'indian/antananarivo': {
     offset: 3,
@@ -1641,7 +1641,7 @@ export default {
   'pacific/auckland': {
     offset: 12,
     hem: 's',
-    'dst': '04/06:03->09/28:04'
+    'dst': '04/06:03->09/28:02'
   },
   'pacific/bougainville': {
     offset: 11,
@@ -1655,7 +1655,7 @@ export default {
   'pacific/easter': {
     offset: -6,
     hem: 's',
-    'dst': '04/05:22->09/06:24'
+    'dst': '04/05:22->09/06:22'
   },
   'pacific/efate': {
     offset: 11,
@@ -1744,7 +1744,7 @@ export default {
   'pacific/norfolk': {
     offset: 11.5,
     hem: 'n',
-    'dst': '04/06:03->10/05:04'
+    'dst': '04/06:03->10/05:02'
   },
   'pacific/noumea': {
     offset: 11,
@@ -1841,56 +1841,56 @@ export default {
   'america/indiana/knox': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/tell_city': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/north_dakota/beulah': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/north_dakota/center': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/north_dakota/new_salem': {
     offset: -5,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/marengo': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/petersburg': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/vevay': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/vincennes': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/indiana/winamac': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   },
   'america/kentucky/monticello': {
     offset: -4,
     hem: 'n',
-    'dst': '03/09:04->11/02:02'
+    'dst': '03/09:02->11/02:02'
   }
 }


### PR DESCRIPTION
The current dst data in 7.7.0 (and likely earlier) is incorrect due to an issue parsing timezone data for generating iana.js file.

The previous implementation checked the last element on the line from zoneinfo zdump, but actually on linux/osx it's the second to last element. This change simply checks for dst=1 anywhere on the line.

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/9812778b-8664-4e32-9986-1ed28e21d5e3" />

After this change, the timezone data (as an example) for America/New_York correctly uses 2am instead of 4am for DST start.

Closes #430 