### PR TITLE
types: fix log and logYear return types

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -130,10 +130,10 @@ export interface Spacetime {
   millenium(millenium: string | number): Spacetime
 
   /** pretty-print the date to the console, for nicer debugging */
-  log: () => string
+  log: () => Spacetime
 
   /** pretty-print the full-date to the console, for nice debugging */
-  logYear: () => string
+  logYear: () => Spacetime
 
   /** return all date units as a key-value map */
   json: () => string


### PR DESCRIPTION
These methods were incorrectly typed. They don't return a string, they log a string to the console and return the original Spacetime.