### PR TITLE
435 Fixing type conflict

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -138,7 +138,7 @@ export interface Spacetime {
   logYear: () => Spacetime
 
   /** return all date units as a key-value map */
-  json: () => object
+  json(): object
   /** set the date via JSON object */
   json(obj: object): Spacetime
 


### PR DESCRIPTION
Fixes the type definition so the two json() functions can overload each other.