### PR TITLE
fix(set): clamp month()/date() day to the target month length

### DIFF
--- a/src/methods/set/set.js
+++ b/src/methods/set/set.js
@@ -2,9 +2,9 @@
 //these methods wrap around them.
 import ms from '../../data/milliseconds.js'
 import { mapping } from '../../data/months.js'
-import monthLength from '../../data/monthLengths.js'
 import walkTo from './walk.js'
 import { isLeapYear } from '../../fns.js'
+import { getMonthLength } from './_model.js'
 
 const validate = (n) => {
   //handle number as a string
@@ -142,14 +142,9 @@ const time = function (s, str, goFwd) {
 
 const date = function (s, n, goFwd) {
   n = validate(n)
-  //avoid setting february 31st
+  //avoid setting february 31st (leap-aware, same as add())
   if (n > 28) {
-    const month = s.month()
-    let max = monthLength[month]
-    // support leap day in february
-    if (month === 1 && n === 29 && isLeapYear(s.year())) {
-      max = 29
-    }
+    const max = getMonthLength(s.month(), s.year())
     if (n > max) {
       n = max
     }
@@ -183,15 +178,16 @@ const month = function (s, n, goFwd) {
   }
 
   let d = s.date()
-  //there's no 30th of february, etc.
-  if (d > monthLength[n]) {
+  //there's no 30th of february, etc. (leap-aware, same as add())
+  const max = getMonthLength(n, s.year())
+  if (d > max) {
     //make it as close as we can..
-    d = monthLength[n]
+    d = max
   }
   const old = s.clone()
   walkTo(s, {
     month: n,
-    d
+    date: d
   })
   s = fwdBkwd(s, old, goFwd, 'year') // specify direction
   return s.epoch

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -222,3 +222,19 @@ test('time parsing edge cases', (t) => {
 
   t.end()
 })
+
+test('month()/date() setters clamp the day to the month length', (t) => {
+  const iso = (s) => s.format('iso-short')
+  // .month() must clamp the day to the target month's length
+  t.equal(iso(spacetime('2020-01-31').month('april')), '2020-04-30', 'jan 31 -> april clamps to the 30th')
+  t.equal(iso(spacetime('2020-01-31').month('june')), '2020-06-30', 'jan 31 -> june clamps to the 30th')
+  // leap-year february
+  t.equal(iso(spacetime('2020-01-31').month('february')), '2020-02-29', 'jan 31 -> feb 29 in a leap year')
+  t.equal(iso(spacetime('2024-01-31').month('february')), '2024-02-29', 'jan 31 -> feb 29 in a leap year')
+  t.equal(iso(spacetime('2021-01-31').month('february')), '2021-02-28', 'jan 31 -> feb 28 in a common year')
+  // .date() must clamp to the same leap-aware length
+  t.equal(iso(spacetime('2020-02-10').date(31)), '2020-02-29', 'date(31) in a leap february clamps to the 29th')
+  t.equal(iso(spacetime('2020-02-10').date(30)), '2020-02-29', 'date(30) in a leap february clamps to the 29th')
+  t.equal(iso(spacetime('2021-02-10').date(31)), '2021-02-28', 'date(31) in a common february clamps to the 28th')
+  t.end()
+})


### PR DESCRIPTION
Two related bugs in the `month()` and `date()` setters when the current day-of-month doesn't fit the month being set.

### `month()` drops the clamped day

The setter computes a clamped day `d` and then calls `walkTo(s, { month: n, d })`. `walkTo` only reads the unit keys it knows about (`year`, `month`, `date`, ...), so the `d` key is silently ignored and the day falls back to the original `date()`. Changing the month off a day that doesn't exist in the target month then lands wherever the internal day-walk happens to stop:

```js
spacetime('2020-01-31').month('april') // 2020-04-24, expected 2020-04-30
spacetime('2020-01-31').month('june')  // 2020-06-19, expected 2020-06-30
```

### Both setters ignore leap years

They read the static `monthLengths` array, where February is always 28, so the day clamps to the 28th even in leap years:

```js
spacetime('2020-01-31').month('february') // 2020-02-28, expected 2020-02-29
spacetime('2020-02-10').date(31)          // 2020-02-28, expected 2020-02-29
```

`add(1, 'month')` already returns the right day after #461, which added the leap-aware `getMonthLength(month, year)` helper. This routes both setters through that same helper and passes the day under the correct `date` key.

Added tests in `test/set.test.js` for the 30-day months and for leap / common February on both setters. The full suite stays green.
