### PR TITLE
fix(timezone): half-hour DST shift for Australia/Lord_Howe

### DIFF
--- a/src/timezone/index.js
+++ b/src/timezone/index.js
@@ -65,12 +65,14 @@ const timezone = s => {
   //(these variable names are north-centric)
   const summer = found.offset // (july)
   let winter = summer // (january) assume it's the same for now
+  //most zones shift by 1hr on dst, but Lord Howe is a ½-hour shift
+  const dstShift = tz === 'australia/lord_howe' ? 0.5 : 1
   if (result.hasDst === true) {
     if (result.hemisphere === 'North') {
-      winter = summer - 1
+      winter = summer - dstShift
     } else {
       //southern hemisphere
-      winter = found.offset + 1
+      winter = found.offset + dstShift
     }
   }
 

--- a/test/dst-south.test.js
+++ b/test/dst-south.test.js
@@ -59,3 +59,28 @@ test('south-increment-nov', (t) => {
   })
   t.end()
 })
+
+// oracle: native Intl offset (minutes) for a UTC instant
+function intlOffsetMin(tz, utcISO) {
+  const v = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
+    .formatToParts(new Date(utcISO))
+    .find((x) => x.type === 'timeZoneName').value // e.g. 'GMT+11:00'
+  const m = v.match(/GMT([+-])(\d{2}):(\d{2})/)
+  if (!m) return 0
+  const sign = m[1] === '-' ? -1 : 1
+  return sign * (+m[2] * 60 + +m[3])
+}
+
+test('Lord Howe half-hour DST offset', (t) => {
+  const tz = 'Australia/Lord_Howe'
+  // January = southern summer = DST on. Intl: +11:00 (660 min).
+  const janUTC = '2026-01-15T00:00:00Z'
+  const jan = spacetime(new Date(janUTC).getTime(), tz)
+  t.equal(jan.offset(), intlOffsetMin(tz, janUTC), 'Lord Howe January offset matches Intl (+11:00)')
+
+  // July = southern winter = standard. Intl: +10:30 (630 min).
+  const julUTC = '2026-07-15T00:00:00Z'
+  const jul = spacetime(new Date(julUTC).getTime(), tz)
+  t.equal(jul.offset(), intlOffsetMin(tz, julUTC), 'Lord Howe July offset matches Intl (+10:30)')
+  t.end()
+})


### PR DESCRIPTION
Australia/Lord_Howe uses a 30-minute DST shift, but spacetime reports it as a full hour, so every instant in the DST half of the year is 30 minutes off.

## Repro

```js
const spacetime = require('spacetime')
const tz = 'Australia/Lord_Howe'

// January = southern summer = DST on
spacetime(new Date('2026-01-15T00:00:00Z').getTime(), tz).offset() // 690  (+11:30)

// native Intl oracle
new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
  .formatToParts(new Date('2026-01-15T00:00:00Z'))
  .find(p => p.type === 'timeZoneName').value // 'GMT+11:00'
```

ACTUAL: `+11:30` (690 min). EXPECTED: `+11:00` (660 min).

## Root cause

In `src/timezone/index.js`, the "other-season" offset is derived by hardcoding a 1-hour DST shift (`winter = summer - 1` north, `found.offset + 1` south). Lord Howe is the only IANA zone with a 30-minute DST shift (standard +10:30, DST +11:00). Its zonefile stores the standard offset `10.5`; adding a full hour yields +11:30 instead of +11:00 for the summer (DST) side. This affects `offset()`, formatting, and UTC-to-wall-clock conversion for the whole DST half of the year.

The July / standard side was already correct (+10:30), because it reads the stored offset directly.

## Fix

Derive the shift per zone and special-case the single half-hour zone:

```js
const dstShift = tz === 'australia/lord_howe' ? 0.5 : 1
```

Then use `dstShift` in place of the hardcoded `1` for both hemispheres.

## Tests

Added a case to `test/dst-south.test.js` that asserts `offset()` against the native `Intl` `longOffset` oracle for both seasons: January `+11:00` and July `+10:30`.

Red baseline: with the source change reverted, the January assertion fails (690 vs 660); July already passes. With the fix, both pass.

Full suite (tape): 6080 tests. Before the fix 12 failed (11 pre-existing America/Denver minute-boundary cases in `test/dst-sneak.test.js`, plus the new Lord Howe case). After the fix 11 fail, all of them the same pre-existing Denver cases, which this change does not touch.
