### PR TITLE
fix(parse): support Date.toString() format

### DIFF
--- a/src/input/formats/02-mdy.js
+++ b/src/input/formats/02-mdy.js
@@ -88,5 +88,26 @@ export default [
       s = parseTime(s, time)
       return s
     }
+  },
+  // Date.toString() - 'Mon Jun 17 2019 11:00:00 GMT-0700 (Pacific Daylight Time)'
+  // (the weekday is already stripped by normalize)
+  {
+    reg: /^([a-z]+) ([0-9]{1,2}) ([0-9]{4}) ([0-9]{1,2}:[0-9]{2}:?[0-9]{0,2}) (?:gmt)?([+-][0-9]{4})/i,
+    parse: (s, arr) => {
+      const [, month, date, year, time, tz] = arr
+      const obj = {
+        year: parseYear(year, s._today),
+        month: parseMonth(month),
+        date: toCardinal(date || '')
+      }
+      if (validate(obj) === false) {
+        s.epoch = null
+        return s
+      }
+      walkTo(s, obj)
+      s = parseOffset(s, tz)
+      s = parseTime(s, time)
+      return s
+    }
   }
 ]

--- a/test/tostring-parse.test.js
+++ b/test/tostring-parse.test.js
@@ -1,0 +1,21 @@
+import test from 'tape'
+import spacetime from './lib/index.js'
+
+// support the format produced by javascript's Date.toString()
+// eg. "Mon Jun 17 2019 11:00:00 GMT-0700 (Pacific Daylight Time)"
+test('Date.toString() format', (t) => {
+  const arr = [
+    ['Mon Jun 17 2019 11:00:00 GMT-0700 (Pacific Daylight Time)', '2019-06-17T11:00:00-07:00'],
+    ['Mon Jun 17 2019 11:00:00 GMT+0530 (India Standard Time)', '2019-06-17T11:00:00+05:30'],
+    ['Sat Feb 01 2020 00:00:00 GMT+0000 (Coordinated Universal Time)', '2020-02-01T00:00:00Z'],
+    // bare numeric offset, no GMT prefix, no tz-name
+    ['Mon Jun 17 2019 11:00:00 -0700', '2019-06-17T11:00:00-07:00']
+  ]
+  arr.forEach((a) => {
+    const left = spacetime(a[0])
+    const right = spacetime(a[1])
+    t.equal(left.isValid(), true, 'is-valid: ' + a[0])
+    t.equal(left.epoch, right.epoch, a[0])
+  })
+  t.end()
+})


### PR DESCRIPTION
## Problem

Strings produced by JavaScript's `Date.toString()`, like
`"Mon Jun 17 2019 11:00:00 GMT-0700 (Pacific Daylight Time)"`, failed to
parse and returned an invalid spacetime.

## Fix

Add an m-d-y parser that accepts a trailing `GMT±HHMM` (or bare `±HHMM`)
offset followed by an optional `(Time Zone Name)` suffix. The weekday is
already stripped by normalize, so the parser matches the `Month Day Year
Time Offset` shape and applies the offset and time.

## Testing

Added `test/tostring-parse.test.js` covering:
- `GMT-0700 (Pacific Daylight Time)`
- `GMT+0530 (India Standard Time)`
- `GMT+0000 (Coordinated Universal Time)`
- bare numeric offset with no `GMT` prefix and no timezone name

Each asserts the result is valid and its epoch matches the equivalent ISO
string.

Closes #148
