### PR TITLE
Fix hour() setter clamping to an invalid hour (24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,9 +702,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,9 +716,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -739,9 +730,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -756,9 +744,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -773,9 +758,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -790,9 +772,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -807,9 +786,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -824,9 +800,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -841,9 +814,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -858,9 +828,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -875,9 +842,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -892,9 +856,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/methods/set/set.js
+++ b/src/methods/set/set.js
@@ -67,8 +67,9 @@ const minutes = function (s, n, goFwd) {
 
 const hours = function (s, n, goFwd) {
   n = validate(n)
+  // Clamp to 0-23: hour 24 is rejected by walkTo(), which nulls the epoch.
   if (n >= 24) {
-    n = 24
+    n = 23
   } else if (n < 0) {
     n = 0
   }

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -238,3 +238,16 @@ test('month()/date() setters clamp the day to the month length', (t) => {
   t.equal(iso(spacetime('2021-02-10').date(31)), '2021-02-28', 'date(31) in a common february clamps to the 28th')
   t.end()
 })
+
+test('hour() setter clamps out-of-range hours to a valid hour', (t) => {
+  const s = spacetime('2021-03-14 10:00:00', 'UTC')
+  // an out-of-range hour must clamp to 23, not null the epoch
+  t.equal(s.hour(24).hour(), 23, 'hour(24) clamps to 23')
+  t.equal(s.hour(25).hour(), 23, 'hour(25) clamps to 23')
+  t.equal(s.hour(100).hour(), 23, 'hour(100) clamps to 23')
+  t.equal(s.hour(24).isValid(), true, 'hour(24) stays valid')
+  t.equal(s.hour(24).format('iso-short'), '2021-03-14', 'hour(24) keeps the same day')
+  // negative hours still clamp to 0
+  t.equal(s.hour(-1).hour(), 0, 'hour(-1) clamps to 0')
+  t.end()
+})


### PR DESCRIPTION

## Problem

Calling `.hour(n)` with `n >= 24` produces an invalid spacetime whose epoch is
`null`, instead of clamping to a valid hour:

```js
const s = spacetime('2021-03-14 10:00:00', 'UTC')

s.hour(24).isValid()      // false
s.hour(24).epoch          // null
s.hour(25).format('iso')  // '' (empty - object is invalid)
```

This is inconsistent with every other overflow-clamping setter:

- `.date(40)` clamps to the last day of the month,
- `.month(13)` clamps to December (11),
- `.hour(-1)` clamps to 0.

Only the upper bound of `.hour()` is broken.

## Root cause

`src/methods/set/set.js`, in `hours()`:

```js
if (n >= 24) {
  n = 24
} else if (n < 0) {
  n = 0
}
```

Valid hours are `0-23`. Clamping to `24` yields a value that
`src/methods/set/walk.js` rejects (`hour.valid: (n) => n >= 0 && n < 24`), and
on an invalid unit `walkTo()` sets `s.epoch = null`, invalidating the whole
object. The negative branch is already correct (clamps to the valid `0`); the
`>= 24` branch is off by one and should clamp to `23`.

## Fix

```js
if (n >= 24) {
  n = 23
} else if (n < 0) {
  n = 0
}
```

`hour(24)`, `hour(25)`, `hour(100)` now all clamp to `23:00` on the same day,
matching the behavior of the other setters.

## Test

Added a test to `test/set.test.js` (next to the existing month/date clamp test)
asserting that out-of-range hours clamp to `23`, keep the object valid, keep the
same day, and that negatives still clamp to `0`.

Counterfactual (revert `n = 23` back to `n = 24`):

```
not ok - hour(24) clamps to 23
  operator: equal
  expected: 23
  actual:   0
```

(the invalid object reports hour `0`).
